### PR TITLE
Add files to a database (fix #72)

### DIFF
--- a/db-init.sql
+++ b/db-init.sql
@@ -69,6 +69,15 @@ CREATE TABLE user_roles (
   role text NOT NULL
 );
 
+CREATE TABLE files (
+  id uuid DEFAULT gen_random_uuid() NOT NULL PRIMARY KEY,
+  originalname text NOT NULL,
+  mimetype text NOT NULL,
+  encoding text NOT NULL,
+  key text NOT NULL,
+  extension text NOT NULL,
+  token uuid NOT NULL
+);
 
 -- alter tables (constraints, FKs etc)
 


### PR DESCRIPTION
> **Untested!** I'm not sure if this works or not.

This is a solution to #72 - a GraphQL endpoint for files. 

It would add a `files` database with the fields returned by the upload, and deletes the row when the file is deleted with the `/storage/delete/*` endpoint.

---

I've used the `.promise()` feature of the AWS SDK, would it be worth using this with async/await instead of callbacks?