### PR TITLE
feat(auth): optional restriction of allowed email domains

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,5 +26,8 @@ HASURA_GRAPHQL_JWT_SECRET_KEY=
 
 # REFRESH_EXPIRES_IN=43200
 
+# Comma-separated list of allowed email addresses, e.g. 'hasura.io,gmail.com'
+# ALLOWED_EMAIL_DOMAINS=
+
 # MAX_REQUESTS=100
 # TIME_FRAME=15 * 60 * 1000


### PR DESCRIPTION
Optional restriction of email adresses to custom domain names set with a `ALLOWED_EMAIL_DOMAINS` environment variable. See #50