### PR TITLE
test: close Express once all the tests are done

### DIFF
--- a/src/routes/auth/auth.test.ts
+++ b/src/routes/auth/auth.test.ts
@@ -7,7 +7,7 @@ import { HasuraUserData } from '@shared/helpers'
 import { request as admin } from '@shared/request'
 import { selectUserByUsername } from '@shared/queries'
 
-import { app } from '../../server'
+import { server } from '../../server'
 
 /**
  * Store variables in memory.
@@ -26,7 +26,7 @@ const password = '1d5e6ceb-f42a-4f2e-b24d-8f1b925971c1'
 /**
  * Create agent for global state.
  */
-const agent = request.agent(app)
+const agent = request.agent(server)
 
 it('should create an account', async () => {
   const { status } = await agent.post('/auth/register').send({ email, password, username })
@@ -163,3 +163,5 @@ it('should delete the user', async () => {
 
   expect(status).toEqual(204)
 })
+
+server.close(() => console.log('Express server closed.'))

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,34 +10,29 @@ import { json } from 'body-parser'
 import { limiter } from './limiter'
 import { router } from './routes'
 
-export const app = express()
+const app = express()
 
-try {
-  if (process.env.NODE_ENV === 'production') {
-    app.use(limiter)
-  }
-
-  app.use(helmet())
-  app.use(json())
-  app.use(cors())
-  app.use(fileUpload())
-
-  /**
-   * Set a cookie secret to enable server validation of cookies.
-   */
-  if (COOKIE_SECRET) {
-    app.use(cookie(COOKIE_SECRET))
-  } else {
-    app.use(cookie())
-  }
-
-  app.use(router)
-  app.use(errors)
-
-  app.listen(SERVER_PORT, () => {
-    console.log(`Running on http://localhost:${SERVER_PORT}`)
-  })
-} catch (err) {
-  console.error(err)
-  process.exit(1)
+if (process.env.NODE_ENV === 'production') {
+  app.use(limiter)
 }
+
+app.use(helmet())
+app.use(json())
+app.use(cors())
+app.use(fileUpload())
+
+/**
+ * Set a cookie secret to enable server validation of cookies.
+ */
+if (COOKIE_SECRET) {
+  app.use(cookie(COOKIE_SECRET))
+} else {
+  app.use(cookie())
+}
+
+app.use(router)
+app.use(errors)
+
+export const server = app.listen(SERVER_PORT, () => {
+  console.log(`Running on http://localhost:${SERVER_PORT}`)
+})


### PR DESCRIPTION
In the auth test, the express server was initialised, but was still running after all tests were performed, leaving jest idle.
This PR fixes this behaviour