### PR TITLE
Correct email requirement in local register

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Use HTTP POST method.
 
 | Variable        | Type          | Required | Comment              |
 | --------------- | ------------- | -------- | -------------------- |
-| `email`         | `string`      | YES      |                      |
+| `email`         | `string`      | NO       |                      |
 | `username`      | `string`      | YES      | can be same as email |
 | `password`      | `string`      | YES      |                      |
 | `register_data` | `json object` | NO       |                      |


### PR DESCRIPTION
As it seems in https://github.com/nhost/hasura-backend-plus/blob/master/src/auth/local.js#L27 email is not marked as required.