### PR TITLE
Create a GH action to publish documentation to GH pages

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,32 @@
+name: Publish Vuepress documentation to GH pages
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Cache dependencies
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - run: yarn
+      - run: yarn run docs:build
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/.vuepress/dist

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,5 +1,6 @@
 module.exports = {
   title: 'Hasura Backend Plus Documentation',
+  base: '/hasura-backend-plus/',
   themeConfig: {
     logo: 'logo.png',
     nav: [


### PR DESCRIPTION
It will require to activate GH pages in the repo settings, I don't have the rights to do it, so you will have to do it @elitan 

Note: this will only work (hopefully) when we will have merged v2 into master as the trigger is on the master branch. It may be appropriate to change the action to be triggered on the v2 branch, and then to change it back once we merged v2 into master