### PR TITLE
Allow email address with a + in the username

### DIFF
--- a/migrations/1587176707868_alter_table_auth_accounts_add_check_constraint_proper_email/down.yaml
+++ b/migrations/1587176707868_alter_table_auth_accounts_add_check_constraint_proper_email/down.yaml
@@ -1,0 +1,11 @@
+- args:
+    cascade: false
+    read_only: false
+    sql: alter table "auth"."accounts" drop constraint "proper_email";
+  type: run_sql
+- args:
+    cascade: false
+    read_only: false
+    sql: alter table "auth"."accounts" add constraint "proper_email" check (CHECK
+      (email ~* '^[A-Za-z0-9._%-]+@[A-Za-z0-9.-]+[.][A-Za-z]+$'::citext));
+  type: run_sql

--- a/migrations/1587176707868_alter_table_auth_accounts_add_check_constraint_proper_email/up.yaml
+++ b/migrations/1587176707868_alter_table_auth_accounts_add_check_constraint_proper_email/up.yaml
@@ -1,0 +1,11 @@
+- args:
+    cascade: false
+    read_only: false
+    sql: alter table "auth"."accounts" drop constraint "proper_email";
+  type: run_sql
+- args:
+    cascade: false
+    read_only: false
+    sql: alter table "auth"."accounts" add constraint "proper_email" check (email
+      ~* '^[A-Za-z0-9._+%-]+@[A-Za-z0-9.-]+[.][A-Za-z]+$'::citext);
+  type: run_sql


### PR DESCRIPTION
One of the famous features of Google Mail is allowing to use the + symbol to easily track where the email is being used. For example, I often use it track where I used my email address e.g. `username+github@gmail.com` or similar. 

Our currently email regex check doesn't allow the + sign in part of the email address this Hasura migration resolves this issue. I discovered this issue when I tried to testing the Twitter auth provider and the email used there was had `+` in it.