### PR TITLE
Update docker-compose.yaml for minio example

### DIFF
--- a/examples/minio/docker-compose.yaml
+++ b/examples/minio/docker-compose.yaml
@@ -5,6 +5,8 @@ services:
     restart: always
     ports:
     - "6432:5432"
+    environment:
+      POSTGRES_PASSWORD: postgrespassword
     volumes:
     - ./db_data:/var/lib/postgresql/data
   pgadmin:
@@ -28,7 +30,7 @@ services:
     - "postgres"
     restart: always
     environment:
-      HASURA_GRAPHQL_DATABASE_URL: postgres://postgres:@postgres:5432/postgres
+      HASURA_GRAPHQL_DATABASE_URL: postgres://postgres:postgrespassword@postgres:5432/postgres
       HASURA_GRAPHQL_ENABLE_CONSOLE: "true" # set to "false" to disable console
       ## uncomment next line to set an access key
       HASURA_GRAPHQL_ADMIN_SECRET: admin


### PR DESCRIPTION
This docker-compose file is not working properly because the postgres password is missing