### PR TITLE
fix error if claim value equals bool false

### DIFF
--- a/src/auth/auth-functions.js
+++ b/src/auth/auth-functions.js
@@ -17,7 +17,7 @@ module.exports = {
         return null;
       }
 
-      custom_claims['x-hasura-' + user_field.replace('_', '-')] = user[user_field] && user[user_field].toString();
+      custom_claims['x-hasura-' + user_field.replace('_', '-')] = user[user_field].toString();
     });
 
     const user_roles = user.user_roles.map(role => {


### PR DESCRIPTION
Hasura expects claim value to be text. Without this fix, if the user_field value is false, the claim value is returned as boolean false. Hasura then triggers an error.

A check for undefined and null value of the user_field are already in place, so no need to check again in this line.