### PR TITLE
Stringify custom claims

### DIFF
--- a/src/shared/jwt.ts
+++ b/src/shared/jwt.ts
@@ -156,7 +156,7 @@ export function createHasuraJwt({
       ...Object.entries(customFields).reduce<{ [k: string]: ClaimValueType }>(
         (aggr, [key, value]) => ({
           ...aggr,
-          [`x-${kebabCase(key)}`]: value
+          [`x-${kebabCase(key)}`]: JSON.stringify(value ?? null)
         }),
         {}
       )


### PR DESCRIPTION
make sure any custom claim value is sent as string as per explained in the #185 v1 PR.

As per the official [Hasura documentation](https://hasura.io/docs/1.0/graphql/manual/auth/authentication/jwt.html):

> All `x-hasura-*` values should be of type `String`, they will be converted to the right type automatically.

