### PR TITLE
Request password

### DIFF
--- a/src/routes/auth/change-password/change.ts
+++ b/src/routes/auth/change-password/change.ts
@@ -21,7 +21,7 @@ async function changePassword({ body, headers }: Request, res: Response): Promis
 
   if (body.ticket) {
     // Reset the password from { ticket, new_password }
-    const { ticket, new_password } = await resetPasswordWithTicketSchema.validateAsync(body, {})
+    const { ticket, new_password } = await resetPasswordWithTicketSchema.validateAsync(body)
 
     await checkHibp(new_password)
     password_hash = await hashPassword(new_password)

--- a/src/routes/auth/change-password/request.ts
+++ b/src/routes/auth/change-password/request.ts
@@ -1,39 +1,74 @@
 import { asyncWrapper, selectAccountByEmail } from '@shared/helpers'
 import { Request, Response } from 'express'
 
-import Boom from '@hapi/boom'
 import { SMTP_ENABLE, SERVER_URL } from '@shared/config'
 import { emailClient } from '@shared/email'
 import { forgotSchema } from '@shared/validation'
-import {} from '@shared/queries'
+import { setNewTicket } from '@shared/queries'
+import { request } from '@shared/request'
+import { v4 as uuidv4 } from 'uuid'
+import Boom from '@hapi/boom'
 
 /**
  * * Creates a new temporary ticket in the account, and optionnaly send the link by email
+ * Always return status code 204 in order to not leak information about emails in our database
  */
 async function requestChangePassword({ body }: Request, res: Response): Promise<unknown> {
+  // smtp must be enabled for request change password to work.
+  if (!SMTP_ENABLE) {
+    throw Boom.badImplementation(
+      'The change password request function is not activated. No SMTP settings available'
+    )
+  }
+
   const { email } = await forgotSchema.validateAsync(body)
 
-  const { ticket } = await selectAccountByEmail(email)
+  const account = await selectAccountByEmail(email)
 
-  if (SMTP_ENABLE) {
-    try {
-      await emailClient.send({
-        template: 'change-password',
-        locals: { ticket, url: SERVER_URL },
-        message: {
-          to: email,
-          headers: {
-            'x-ticket': {
-              prepared: true,
-              value: ticket as string
-            }
+  if (!account) {
+    console.error('Account does not exist')
+    return res.status(204).send()
+  }
+
+  // generate new ticket and ticket_expires_at
+  const ticket = uuidv4()
+  const now = new Date()
+  const ticket_expires_at = new Date()
+
+  // ticket active for 30 minutes
+  ticket_expires_at.setTime(now.getTime() + 30 * 60 * 1000)
+
+  // set new ticket
+  try {
+    await request(setNewTicket, {
+      user_id: account.user.id,
+      ticket,
+      ticket_expires_at
+    })
+  } catch (error) {
+    console.error('Unable to set new ticket for user')
+    return res.status(204).send()
+  }
+
+  // send email
+  try {
+    await emailClient.send({
+      template: 'change-password',
+      locals: { ticket, url: SERVER_URL },
+      message: {
+        to: email,
+        headers: {
+          'x-ticket': {
+            prepared: true,
+            value: ticket as string
           }
         }
-      })
-    } catch (err) {
-      console.error(err)
-      throw Boom.badImplementation()
-    }
+      }
+    })
+  } catch (err) {
+    console.error('Unable to send email')
+    console.error(err)
+    return res.status(204).send()
   }
 
   return res.status(204).send()

--- a/src/routes/auth/change-password/request.ts
+++ b/src/routes/auth/change-password/request.ts
@@ -11,7 +11,7 @@ import Boom from '@hapi/boom'
 
 /**
  * * Creates a new temporary ticket in the account, and optionnaly send the link by email
- * Always return status code 204 in order to not leak information about emails in our database
+ * Always return status code 204 in order to not leak information about emails in the database
  */
 async function requestChangePassword({ body }: Request, res: Response): Promise<unknown> {
   // smtp must be enabled for request change password to work.
@@ -30,13 +30,18 @@ async function requestChangePassword({ body }: Request, res: Response): Promise<
     return res.status(204).send()
   }
 
+  if (!account.active) {
+    console.error('Account is not active')
+    return res.status(204).send()
+  }
+
   // generate new ticket and ticket_expires_at
   const ticket = uuidv4()
   const now = new Date()
   const ticket_expires_at = new Date()
 
-  // ticket active for 30 minutes
-  ticket_expires_at.setTime(now.getTime() + 30 * 60 * 1000)
+  // ticket active for 60 minutes
+  ticket_expires_at.setTime(now.getTime() + 60 * 60 * 1000)
 
   // set new ticket
   try {

--- a/src/shared/queries.ts
+++ b/src/shared/queries.ts
@@ -35,6 +35,17 @@ export const insertAccount = gql`
   ${accountFragment}
 `
 
+export const setNewTicket = gql`
+  mutation($ticket: uuid!, $ticket_expires_at: timestamptz!, $user_id: uuid!) {
+    update_auth_accounts(
+      _set: { ticket: $ticket, ticket_expires_at: $ticket_expires_at }
+      where: { user: { id: { _eq: $user_id } } }
+    ) {
+      affected_rows
+    }
+  }
+`
+
 export const updatePasswordWithTicket = gql`
   mutation($now: timestamptz!, $ticket: uuid!, $password_hash: String!, $new_ticket: uuid!) {
     update_auth_accounts(
@@ -67,7 +78,7 @@ export const selectAccountByUserId = gql`
 `
 
 export const selectAccountByEmail = gql`
-  query($email: String!) {
+  query($email: citext!) {
     auth_accounts(where: { email: { _eq: $email } }) {
       ...accountFragment
     }
@@ -204,7 +215,7 @@ export const deleteAccountByUserId = gql`
 `
 
 export const changeEmailByTicket = gql`
-  mutation($now: timestamptz, $ticket: uuid!, $new_email: String, $new_ticket: uuid!) {
+  mutation($now: timestamptz, $ticket: uuid!, $new_email: citext, $new_ticket: uuid!) {
     update_auth_accounts(
       where: { _and: [{ ticket: { _eq: $ticket } }, { ticket_expires_at: { _lt: $now } }] }
       _set: { email: $new_email, new_email: null, ticket: $new_ticket, ticket_expires_at: $now }
@@ -215,7 +226,7 @@ export const changeEmailByTicket = gql`
 `
 
 export const saveNewEmail = gql`
-  mutation($email: String!, $new_email: String!) {
+  mutation($email: citext!, $new_email: citext!) {
     update_auth_accounts(where: { email: { _eq: $email } }, _set: { new_email: $new_email }) {
       affected_rows
     }

--- a/src/shared/queries.ts
+++ b/src/shared/queries.ts
@@ -49,7 +49,7 @@ export const setNewTicket = gql`
 export const updatePasswordWithTicket = gql`
   mutation($now: timestamptz!, $ticket: uuid!, $password_hash: String!, $new_ticket: uuid!) {
     update_auth_accounts(
-      where: { _and: [{ ticket: { _eq: $ticket } }, { ticket_expires_at: { _lt: $now } }] }
+      where: { _and: [{ ticket: { _eq: $ticket } }, { ticket_expires_at: { _gt: $now } }] }
       _set: { password_hash: $password_hash, ticket: $new_ticket, ticket_expires_at: $now }
     ) {
       affected_rows


### PR DESCRIPTION
- SMTP must be activated for change-password/request endpoint to be active
- New ticket is generated on new change-password request.
- We always return http status code 204 even if things fail or are not found to not leak information if the email was in the database or not.
- Only allow active accounts to request new password change.
- Bug fixes