### PR TITLE
Storage access token

### DIFF
--- a/custom/storage-rules/rules.yaml
+++ b/custom/storage-rules/rules.yaml
@@ -13,4 +13,4 @@ paths:
       read: 'isOwner(userId)'
       write: 'isOwner(userId)'
       values:
-        token: 'request.query.token'
+        description: 'request.query.description'

--- a/src/routes/storage/storage.test.ts
+++ b/src/routes/storage/storage.test.ts
@@ -9,6 +9,7 @@ const readFile = promisify(fs.readFile)
 const filePath = 'package.json'
 let fileToken: string
 const initialDescription = 'description of the file'
+const newDescription = 'new description'
 
 it('should upload a new file', async () => {
   const {
@@ -72,7 +73,7 @@ it(`should update an existing file's metadata`, async () => {
   const { status } = await request
     .post(`/storage/meta/user/${getUserId()}/${filePath}`)
     .set('Authorization', `Bearer ${account.token}`)
-    .query({ description: 'new description' })
+    .query({ description: newDescription })
   expect(status).toEqual(200)
 })
 
@@ -87,7 +88,7 @@ it('should get file metadata', async () => {
     .set('Authorization', `Bearer ${account.token}`)
   expect(status).toEqual(200)
   expect(filename).toEqual(filePath)
-  expect(description).toEqual('new description')
+  expect(description).toEqual(newDescription)
 })
 
 it('should get the headers of all the user files', async () => {

--- a/src/routes/storage/upload.ts
+++ b/src/routes/storage/upload.ts
@@ -1,4 +1,5 @@
 import { NextFunction, Request, Response } from 'express'
+import { v4 as uuidv4 } from 'uuid'
 import {
   StoragePermissions,
   createContext,
@@ -47,6 +48,7 @@ export const uploadFile = async (
       ContentType: resource.mimetype,
       Metadata: {
         filename: resource.name,
+        token: uuidv4(),
         ...(oldHeadObject?.Metadata || {}),
         ...generateMetadata(metadata, context)
       }

--- a/src/routes/storage/utils.ts
+++ b/src/routes/storage/utils.ts
@@ -1,5 +1,6 @@
 import { getClaims } from '@shared/jwt'
 import safeEval, { FunctionFactory } from 'notevil'
+import { v4 as uuidv4 } from 'uuid'
 
 import Boom from '@hapi/boom'
 import { HeadObjectOutput } from 'aws-sdk/clients/s3'
@@ -155,7 +156,9 @@ export const replaceMetadata = async (
     CopySource: `${S3_BUCKET}/${key}`,
     ContentType: oldHeadObject?.ContentType,
     Metadata: {
-      ...((keepOldMetadata && oldHeadObject?.Metadata) || {}),
+      ...((keepOldMetadata && oldHeadObject?.Metadata) || {
+        token: uuidv4()
+      }),
       ...newMetadata
     },
     MetadataDirective: 'REPLACE'


### PR DESCRIPTION
let the server generate an access `token` in the metadata of each s3 object.
By default, the access token is not activated on any rule, but can be used for instance in setting this test: `request.query.token === resource.Metadata.token`

If metadata rules allow, an user can however:
- change the token when metadata update is allowed
- reset the token in deleting metadata