### PR TITLE
Host default value

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,7 @@ SERVER_URL=
 # PORT=3000
 
 ## Host that HBP will listen on
-# HOST=localhost
+# HOST=
 
 ## Automatically loads the SQL schema and Hasura metadata on startup.
 ## AUTO_MIGRATE=v1 migrates from HBP v1 to v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next release
 
 - build: Run HBP with node instead of ts-node for lower memory consumption
+- server + docs: Set "HOST" default value to empty
 
 ## v2.0.0-rc.4
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM node:14.4.0-alpine3.11
 ARG NODE_ENV=production
 ENV NODE_ENV $NODE_ENV
 ENV PORT 3000
-ENV HOST localhost
 
 WORKDIR /app
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -3,7 +3,6 @@ FROM node:14.4.0-alpine3.11
 ARG NODE_ENV=development
 ENV NODE_ENV $NODE_ENV
 ENV PORT 3000
-ENV HOST localhost
 
 WORKDIR /app
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -201,15 +201,15 @@ Any given field must exist in the `users` GraphQL type that corresponds to the `
 
 ### General
 
-| Name                          | Default   | Description                                                                                                 |
-| ----------------------------- | --------- | ----------------------------------------------------------------------------------------------------------- |
-| `HASURA_ENDPOINT` (required)  |           | Url of the Hasura GraphQL engine endpoint used by the backend to access the database.                       |
-| `HASURA_GRAPHQL_ADMIN_SECRET` |           | The secret set in the Hasura GraphQL Engine to allow admin access to the service. **Strongly recommended**. |
-| `HOST`                        | localhost | Listening ip of the service                                                                                 |
-| `PORT`                        | 3000      | Port of the service                                                                                         |
-| `SERVER_URL`                  |           | Current server URL. Currently used only for creating links from email templates                             |
-| `MAX_REQUESTS`                | 100       | Maximum requests per IP within the following `TIME_FRAME`.                                                  |
-| `TIME_FRAME`                  | 900000    | Timeframe used to limit requests from the same IP, in milliseconds. Defaults to 15 minutes.                 |
+| Name                          | Default | Description                                                                                                 |
+| ----------------------------- | ------- | ----------------------------------------------------------------------------------------------------------- |
+| `HASURA_ENDPOINT` (required)  |         | Url of the Hasura GraphQL engine endpoint used by the backend to access the database.                       |
+| `HASURA_GRAPHQL_ADMIN_SECRET` |         | The secret set in the Hasura GraphQL Engine to allow admin access to the service. **Strongly recommended**. |
+| `HOST`                        |         | Listening host of the service                                                                               |
+| `PORT`                        | 3000    | Port of the service                                                                                         |
+| `SERVER_URL`                  |         | Current server URL. Currently used only for creating links from email templates                             |
+| `MAX_REQUESTS`                | 100     | Maximum requests per IP within the following `TIME_FRAME`.                                                  |
+| `TIME_FRAME`                  | 900000  | Timeframe used to limit requests from the same IP, in milliseconds. Defaults to 15 minutes.                 |
 
 ### Authentication
 

--- a/src/shared/config/application.ts
+++ b/src/shared/config/application.ts
@@ -8,7 +8,7 @@ export const {
   REDIRECT_URL_ERROR,
   REDIRECT_URL_SUCCESS,
   HASURA_GRAPHQL_ADMIN_SECRET,
-  HOST = 'localhost'
+  HOST = ''
 } = process.env
 export const PORT = castIntEnv('PORT', 3000)
 export const HASURA_ENDPOINT = process.env.HASURA_ENDPOINT as string

--- a/src/start.ts
+++ b/src/start.ts
@@ -11,7 +11,13 @@ const start = async (): Promise<void> => {
     }
     await migrate(migrationSetup)
   }
-  app.listen(PORT, HOST, () => console.log(`Running on http://${HOST}:${PORT}`))
+  app.listen(PORT, HOST, () => {
+    if (HOST) {
+      console.log(`Running on http://${HOST}:${PORT}`)
+    } else {
+      console.log(`Running on port ${PORT}`)
+    }
+  })
 }
 
 start()


### PR DESCRIPTION
fixes #262

https://nodejs.org/api/net.html#net_server_listen_port_host_backlog_callback

`If host is omitted, the server will accept connections on the unspecified IPv6 address (::) when IPv6 is available, or the unspecified IPv4 address (0.0.0.0) otherwise.`