### PR TITLE
fix: when running on dev mode, use aliases in src/ and not in dist/. …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN yarn install
 
 COPY . .
 
-RUN ./node_modules/typescript/bin/tsc -p .
+RUN yarn build
 
 HEALTHCHECK --interval=60s --timeout=2s --retries=3 CMD wget ${HOST}:${PORT}/healthz -q -O - > /dev/null 2>&1
 

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
   "version": "2.0.0",
   "main": "src/start.ts",
   "scripts": {
-    "dev": "ts-node-dev -r tsconfig-paths/register --no-notify src/start.ts",
-    "dev:docker": "ts-node-dev -r tsconfig-paths/register --no-deps --respawn --poll --interval 1000 --no-notify src/start.ts",
+    "build": "tsc",
+    "dev": "ts-node-dev -r tsconfig-paths/register --no-notify src/ts-start.ts",
+    "dev:docker": "ts-node-dev -r tsconfig-paths/register --no-deps --respawn --poll --interval 1000 --no-notify src/ts-start.ts",
     "docs:build": "vuepress build docs",
     "docs:dev": "vuepress dev docs",
     "start": "node -r ./prod-paths.js ./dist/start.js",

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -30,16 +30,21 @@ const waitFor = async (path: string, attempts = 240): Promise<void> => {
 }
 
 const hasuraConsole = async (action: string): Promise<void> => {
-  const child = spawn('./node_modules/.bin/hasura', [
-    ...action.split(' '),
-    '--log-level',
-    LOG_LEVEL,
-    '--skip-update-check',
-    '--project',
-    TEMP_MIGRATION_DIR
-  ])
-  for await (const data of child.stdout) {
-    process.stdout.write(data.toString())
+  try {
+    const child = spawn('./node_modules/.bin/hasura', [
+      ...action.split(' '),
+      '--log-level',
+      LOG_LEVEL,
+      '--skip-update-check',
+      '--project',
+      TEMP_MIGRATION_DIR
+    ])
+    for await (const data of child.stdout) {
+      process.stdout.write(data.toString())
+    }
+  } catch (error) {
+    console.log('Error in starting hasura cli')
+    console.log(error)
   }
 }
 

--- a/src/start.ts
+++ b/src/start.ts
@@ -1,23 +1,2 @@
 require('module-alias/register')
-import { HOST, PORT, AUTO_MIGRATE } from '@shared/config'
-import { app } from './server'
-import migrate from './migrate'
-
-const start = async (): Promise<void> => {
-  if (AUTO_MIGRATE) {
-    const migrationSetup = {
-      migrations: AUTO_MIGRATE === 'v1' ? './migrations-v1' : './migrations'
-      // metadata: './metadata'
-    }
-    await migrate(migrationSetup)
-  }
-  app.listen(PORT, HOST, () => {
-    if (HOST) {
-      console.log(`Running on http://${HOST}:${PORT}`)
-    } else {
-      console.log(`Running on port ${PORT}`)
-    }
-  })
-}
-
-start()
+import './ts-start'

--- a/src/ts-start.ts
+++ b/src/ts-start.ts
@@ -1,0 +1,22 @@
+import { HOST, PORT, AUTO_MIGRATE } from '@shared/config'
+import { app } from './server'
+import migrate from './migrate'
+
+const start = async (): Promise<void> => {
+  if (AUTO_MIGRATE) {
+    const migrationSetup = {
+      migrations: AUTO_MIGRATE === 'v1' ? './migrations-v1' : './migrations'
+      // metadata: './metadata'
+    }
+    await migrate(migrationSetup)
+  }
+  app.listen(PORT, HOST, () => {
+    if (HOST) {
+      console.log(`Running on http://${HOST}:${PORT}`)
+    } else {
+      console.log(`Running on port ${PORT}`)
+    }
+  })
+}
+
+start()


### PR DESCRIPTION
…Update package.json accordingly

TS aliases are managed by tsconfig.json, whereas JS aliases are managed by the module-alias package.
They conflict if ts-node evaluates `require('module-alias/register')`

fix #283