### PR TITLE
Fix docker start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN yarn install
 
 COPY . .
 
-RUN ./node_modules/typescript/bin/tsc -p .
+RUN yarn build
 
 HEALTHCHECK --interval=60s --timeout=2s --retries=3 CMD wget ${HOST}:${PORT}/healthz -q -O - > /dev/null 2>&1
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dev:docker": "ts-node-dev -r tsconfig-paths/register --no-deps --respawn --poll --interval 1000 --no-notify src/ts-start.ts",
     "docs:build": "vuepress build docs",
     "docs:dev": "vuepress dev docs",
-    "start": "node -r ./prod-paths.js ./dist/start.js",
+    "start": "node -r ./prod-paths.js ./dist/src/start.js",
     "test": "NODE_ENV=test jest --coverage --forceExit --runInBand",
     "test:ci": "NODE_ENV=ci jest --coverage --forceExit --runInBand",
     "test:watch": "NODE_ENV=test jest --watch",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
   "version": "2.0.0",
   "main": "src/start.ts",
   "scripts": {
-    "dev": "ts-node-dev -r tsconfig-paths/register --no-notify src/start.ts",
-    "dev:docker": "ts-node-dev -r tsconfig-paths/register --no-deps --respawn --poll --interval 1000 --no-notify src/start.ts",
+    "build": "tsc",
+    "dev": "ts-node-dev -r tsconfig-paths/register --no-notify src/ts-start.ts",
+    "dev:docker": "ts-node-dev -r tsconfig-paths/register --no-deps --respawn --poll --interval 1000 --no-notify src/ts-start.ts",
     "docs:build": "vuepress build docs",
     "docs:dev": "vuepress dev docs",
     "start": "node -r ./prod-paths.js ./dist/start.js",

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -30,16 +30,21 @@ const waitFor = async (path: string, attempts = 240): Promise<void> => {
 }
 
 const hasuraConsole = async (action: string): Promise<void> => {
-  const child = spawn('./node_modules/.bin/hasura', [
-    ...action.split(' '),
-    '--log-level',
-    LOG_LEVEL,
-    '--skip-update-check',
-    '--project',
-    TEMP_MIGRATION_DIR
-  ])
-  for await (const data of child.stdout) {
-    process.stdout.write(data.toString())
+  try {
+    const child = spawn('./node_modules/.bin/hasura', [
+      ...action.split(' '),
+      '--log-level',
+      LOG_LEVEL,
+      '--skip-update-check',
+      '--project',
+      TEMP_MIGRATION_DIR
+    ])
+    for await (const data of child.stdout) {
+      process.stdout.write(data.toString())
+    }
+  } catch (error) {
+    console.log('Error in starting hasura cli')
+    console.log(error)
   }
 }
 

--- a/src/start.ts
+++ b/src/start.ts
@@ -1,23 +1,2 @@
 require('module-alias/register')
-import { HOST, PORT, AUTO_MIGRATE } from '@shared/config'
-import { app } from './server'
-import migrate from './migrate'
-
-const start = async (): Promise<void> => {
-  if (AUTO_MIGRATE) {
-    const migrationSetup = {
-      migrations: AUTO_MIGRATE === 'v1' ? './migrations-v1' : './migrations'
-      // metadata: './metadata'
-    }
-    await migrate(migrationSetup)
-  }
-  app.listen(PORT, HOST, () => {
-    if (HOST) {
-      console.log(`Running on http://${HOST}:${PORT}`)
-    } else {
-      console.log(`Running on port ${PORT}`)
-    }
-  })
-}
-
-start()
+import './ts-start'

--- a/src/ts-start.ts
+++ b/src/ts-start.ts
@@ -1,0 +1,22 @@
+import { HOST, PORT, AUTO_MIGRATE } from '@shared/config'
+import { app } from './server'
+import migrate from './migrate'
+
+const start = async (): Promise<void> => {
+  if (AUTO_MIGRATE) {
+    const migrationSetup = {
+      migrations: AUTO_MIGRATE === 'v1' ? './migrations-v1' : './migrations'
+      // metadata: './metadata'
+    }
+    await migrate(migrationSetup)
+  }
+  app.listen(PORT, HOST, () => {
+    if (HOST) {
+      console.log(`Running on http://${HOST}:${PORT}`)
+    } else {
+      console.log(`Running on port ${PORT}`)
+    }
+  })
+}
+
+start()


### PR DESCRIPTION
The `version` endpoint now requires  `package.json` at runtime.

As a consequence, tsc compilation ends up in creating a `dist/package.json` file, but also nests the rest of the code in a `dist/src` folder instead of directly putting the files in `dist`.

As a consequence, the `start.js` file path is not `dist/start.js` but `dist/src/start.js`.

The start script has been corrected in package.json, but IMO I feel this dist/src folder is a bit ugly.

The problem could be solved in setting `resolveJsonModule: false` in `tsconfig.json`, but it implies to deactivate the version endpoint, or to find a workaround.

Bug probably created by #275 

