### PR TITLE
Return key on upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - build: reduction of the docker image from 617MB to 216MB (#291)
 - server: Add `SameSite=None` header to mitigate future cross-site errors from Chrome (#294)
 - server: Removed `X-Frame-Options` for GET storage requests.
+- server: Return file key on upload
 
 ## v2.0.0-rc.4
 

--- a/src/routes/storage/upload.ts
+++ b/src/routes/storage/upload.ts
@@ -51,5 +51,6 @@ export const uploadFile = async (
     throw Boom.notImplemented('Setting metadata is not implemented')
     // await replaceMetadata(req, true, generateMetadata(metadata, context))
   }
-  return res.status(200).send(await getHeadObject(req))
+  const headObject = await getHeadObject(req)
+  return res.status(200).send({ key, ...headObject })
 }


### PR DESCRIPTION
When you get the file metadata, the file key is returned too:

https://github.com/nhost/hasura-backend-plus/blob/master/src/routes/storage/get.ts#L26-L28

This should be the same for when you initially upload the file:

https://github.com/nhost/hasura-backend-plus/blob/master/src/routes/storage/upload.ts#L54