### PR TITLE
New auth middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next release
 
 - server: `display_name` is attached for email templates
+- server: Added auth middleware to suppor non-cookie approach for refresh and jwt tokens
 
 ## v2.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Next release
 
 - server: `display_name` is attached for email templates
-- server: Added auth middleware to suppor non-cookie approach for refresh and jwt tokens
+- server: Added auth middleware to support non-cookie approach for refresh and JWT tokens
 
 ## v2.1.1
 

--- a/custom/storage-rules/rules.yaml
+++ b/custom/storage-rules/rules.yaml
@@ -8,3 +8,6 @@ paths:
   /user/:userId/:fileId:
     read: 'isOwner(userId) || validToken()'
     write: 'isOwner(userId)'
+  /public*:
+    read: 'true'
+    write: 'true'

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,4 +1,5 @@
-import { NextFunction, Request, Response } from 'express'
+import { NextFunction, Response } from 'express'
+import { RequestExtended } from '@shared/types'
 
 interface Error {
   output?: {
@@ -18,7 +19,7 @@ interface Error {
  */
 export async function errors(
   err: Error,
-  _req: Request,
+  _req: RequestExtended,
   res: Response,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   next: NextFunction

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -1,0 +1,53 @@
+import { Response, NextFunction } from 'express'
+import { COOKIE_SECRET } from '@shared/config'
+import { RefreshTokenMiddleware, RequestExtended } from '@shared/types'
+import { getClaims } from '@shared/jwt'
+
+export function authMiddleware(req: RequestExtended, res: Response, next: NextFunction): void {
+  let refresh_token = {
+    value: null,
+    type: null
+  } as RefreshTokenMiddleware
+  // let permission_variables = {};
+
+  // check for Authorization header
+  let claims
+  try {
+    claims = getClaims(req.headers.authorization)
+  } catch (e) {
+    // noop
+    console.log('unable to get claims from authorization header')
+  }
+
+  console.log('claims:')
+  console.log(claims)
+
+  // check for refresh token in body?
+  if ('refresh_token' in req.query) {
+    refresh_token = {
+      value: req.query.refresh_token as string,
+      type: 'query'
+    }
+  }
+
+  // check for cookies
+  const cookies_in_use = COOKIE_SECRET ? req.signedCookies : req.cookies
+
+  if ('refresh_token' in cookies_in_use) {
+    refresh_token = {
+      value: cookies_in_use.refresh_token,
+      type: 'cookie'
+    }
+  }
+
+  if ('permission_variables' in cookies_in_use) {
+    // permission_variables =
+  }
+
+  console.log({ refresh_token })
+
+  req.refresh_token = refresh_token
+
+  // if (refresh_token) console.log('in auth middleware')
+  next()
+}

--- a/src/routes/auth/auth.test.ts
+++ b/src/routes/auth/auth.test.ts
@@ -117,7 +117,7 @@ it('should complain about incorrect email', async () => {
 })
 
 it('should sign the user in', async () => {
-  const { body, status } = await request.post('/auth/login').send({ email, password })
+  const { body, status } = await request.post('/auth/login').send({ email, password, cookie: true })
   // Save JWT token to globally scoped varaible.
   jwtToken = body.jwt_token
   expect(status).toEqual(200)

--- a/src/routes/auth/change-email/direct-change.ts
+++ b/src/routes/auth/change-email/direct-change.ts
@@ -1,12 +1,13 @@
-import { Request, Response } from 'express'
+import { Response } from 'express'
 
 import { asyncWrapper } from '@shared/helpers'
 import { changeEmailByUserId } from '@shared/queries'
 import { request } from '@shared/request'
 
 import { getRequestInfo } from './utils'
+import { RequestExtended } from '@shared/types'
 
-async function requestChangeEmail(req: Request, res: Response): Promise<unknown> {
+async function requestChangeEmail(req: RequestExtended, res: Response): Promise<unknown> {
   const { user_id, new_email } = await getRequestInfo(req)
 
   // * Email verification is not activated - change email straight away

--- a/src/routes/auth/change-email/request-verification.ts
+++ b/src/routes/auth/change-email/request-verification.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from 'express'
+import { Response } from 'express'
 import { v4 as uuidv4 } from 'uuid'
 import Boom from '@hapi/boom'
 
@@ -9,8 +9,9 @@ import { emailClient } from '@shared/email'
 import { request } from '@shared/request'
 
 import { getRequestInfo } from './utils'
+import { RequestExtended } from '@shared/types'
 
-async function requestChangeEmail(req: Request, res: Response): Promise<unknown> {
+async function requestChangeEmail(req: RequestExtended, res: Response): Promise<unknown> {
   const { user_id, new_email } = await getRequestInfo(req)
 
   // smtp must be enabled for request change password to work.

--- a/src/routes/auth/change-email/utils.ts
+++ b/src/routes/auth/change-email/utils.ts
@@ -1,14 +1,16 @@
-import { Request } from 'express'
-import { selectAccountByEmail, getPermissionVariablesFromCookie } from '@shared/helpers'
+import { selectAccountByEmail } from '@shared/helpers'
 import { emailResetSchema } from '@shared/validation'
 import Boom from '@hapi/boom'
+import { RequestExtended } from '@shared/types'
 
 export const getRequestInfo = async (
-  req: Request
+  req: RequestExtended
 ): Promise<{ user_id: string | number; new_email: string }> => {
-  // get current user_id
-  const permission_variables = getPermissionVariablesFromCookie(req)
-  const user_id = permission_variables['user-id']
+  if (!req.permission_variables) {
+    throw Boom.unauthorized('Not logged in')
+  }
+
+  const { 'user-id': user_id } = req.permission_variables
 
   // validate new email
   const { new_email } = await emailResetSchema.validateAsync(req.body)

--- a/src/routes/auth/change-password/change.test.ts
+++ b/src/routes/auth/change-password/change.test.ts
@@ -12,3 +12,33 @@ it('should change the password from the old password', async () => {
   expect(status).toEqual(204)
   // ? check if the hash has been changed in the DB?
 })
+
+describe('change password without cookies', () => {
+  let jwtToken: string
+
+  // to make sure no cookies are set
+  it('Should logout user', async () => {
+    const { status } = await request.post('/auth/logout')
+    expect(status).toEqual(204)
+  })
+
+  it('Should login without cookies', async () => {
+    const { body, status } = await request
+      .post('/auth/login')
+      .send({ email: account.email, password: account.password, cookie: false })
+    // Save JWT token to globally scoped varaible.
+    jwtToken = body.jwt_token
+
+    expect(status).toEqual(200)
+  })
+
+  it('should change password using old password', async () => {
+    const new_password = generateRandomString()
+    const { status } = await request
+      .post('/auth/change-password')
+      .set({ Authorization: `Bearer ${jwtToken}` })
+      .send({ old_password: account.password, new_password })
+    account.password = new_password
+    expect(status).toEqual(204)
+  })
+})

--- a/src/routes/auth/change-password/change.test.ts
+++ b/src/routes/auth/change-password/change.test.ts
@@ -22,7 +22,7 @@ describe('change password without cookies', () => {
     expect(status).toEqual(204)
   })
 
-  it('Should login without cookies', async () => {
+  it('Should login user', async () => {
     const { body, status } = await request
       .post('/auth/login')
       .send({ email: account.email, password: account.password, cookie: false })

--- a/src/routes/auth/change-password/change.ts
+++ b/src/routes/auth/change-password/change.ts
@@ -2,13 +2,7 @@ import { Response } from 'express'
 import Boom from '@hapi/boom'
 import bcrypt from 'bcryptjs'
 
-import {
-  asyncWrapper,
-  checkHibp,
-  hashPassword,
-  selectAccountByUserId,
-  getPermissionVariablesFromCookie
-} from '@shared/helpers'
+import { asyncWrapper, checkHibp, hashPassword, selectAccountByUserId } from '@shared/helpers'
 import { changePasswordFromOldSchema } from '@shared/validation'
 import { updatePasswordWithUserId } from '@shared/queries'
 import { request } from '@shared/request'
@@ -18,7 +12,10 @@ import { RequestExtended } from '@shared/types'
  * Change the password from the current one
  */
 async function basicPasswordChange(req: RequestExtended, res: Response): Promise<unknown> {
-  // get current user_id
+  if (!req.permission_variables) {
+    throw Boom.unauthorized('Not logged in')
+  }
+
   const { 'user-id': user_id } = req.permission_variables
 
   const { old_password, new_password } = await changePasswordFromOldSchema.validateAsync(req.body)

--- a/src/routes/auth/change-password/change.ts
+++ b/src/routes/auth/change-password/change.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from 'express'
+import { Response } from 'express'
 import Boom from '@hapi/boom'
 import bcrypt from 'bcryptjs'
 
@@ -12,13 +12,14 @@ import {
 import { changePasswordFromOldSchema } from '@shared/validation'
 import { updatePasswordWithUserId } from '@shared/queries'
 import { request } from '@shared/request'
+import { RequestExtended } from '@shared/types'
 
 /**
  * Change the password from the current one
  */
-async function basicPasswordChange(req: Request, res: Response): Promise<unknown> {
+async function basicPasswordChange(req: RequestExtended, res: Response): Promise<unknown> {
   // get current user_id
-  const { 'user-id': user_id } = getPermissionVariablesFromCookie(req)
+  const { 'user-id': user_id } = req.permission_variables
 
   const { old_password, new_password } = await changePasswordFromOldSchema.validateAsync(req.body)
 

--- a/src/routes/auth/change-password/reset.ts
+++ b/src/routes/auth/change-password/reset.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from 'express'
+import { Response } from 'express'
 import { v4 as uuidv4 } from 'uuid'
 import Boom from '@hapi/boom'
 
@@ -6,12 +6,12 @@ import { asyncWrapper, checkHibp, hashPassword } from '@shared/helpers'
 import { resetPasswordWithTicketSchema } from '@shared/validation'
 import { updatePasswordWithTicket } from '@shared/queries'
 import { request } from '@shared/request'
-import { UpdateAccountData } from '@shared/types'
+import { UpdateAccountData, RequestExtended } from '@shared/types'
 
 /**
  * Reset the password, either from a valid ticket or from a valid JWT and a valid password
  */
-async function resetPassword(req: Request, res: Response): Promise<unknown> {
+async function resetPassword(req: RequestExtended, res: Response): Promise<unknown> {
   // Reset the password from { ticket, new_password }
   const { ticket, new_password } = await resetPasswordWithTicketSchema.validateAsync(req.body)
 

--- a/src/routes/auth/delete.ts
+++ b/src/routes/auth/delete.ts
@@ -7,6 +7,10 @@ import { request } from '@shared/request'
 import { DeleteAccountData, RequestExtended } from '@shared/types'
 
 async function deleteUser(req: RequestExtended, res: Response): Promise<unknown> {
+  if (!req.permission_variables) {
+    throw Boom.unauthorized('Unable to delete account')
+  }
+
   const { 'user-id': user_id } = req.permission_variables
 
   const hasuraData = await request<DeleteAccountData>(deleteAccountByUserId, { user_id })

--- a/src/routes/auth/delete.ts
+++ b/src/routes/auth/delete.ts
@@ -1,14 +1,13 @@
-import { Request, Response } from 'express'
+import { Response } from 'express'
 
 import Boom from '@hapi/boom'
-import { asyncWrapper, getPermissionVariablesFromCookie } from '@shared/helpers'
+import { asyncWrapper } from '@shared/helpers'
 import { deleteAccountByUserId } from '@shared/queries'
 import { request } from '@shared/request'
-import { DeleteAccountData } from '@shared/types'
+import { DeleteAccountData, RequestExtended } from '@shared/types'
 
-async function deleteUser(req: Request, res: Response): Promise<unknown> {
-  const permission_variables = getPermissionVariablesFromCookie(req)
-  const user_id = permission_variables['user-id']
+async function deleteUser(req: RequestExtended, res: Response): Promise<unknown> {
+  const { 'user-id': user_id } = req.permission_variables
 
   const hasuraData = await request<DeleteAccountData>(deleteAccountByUserId, { user_id })
 

--- a/src/routes/auth/jwks.ts
+++ b/src/routes/auth/jwks.ts
@@ -1,9 +1,10 @@
-import { Request, Response } from 'express'
+import { Response } from 'express'
 
 import { asyncWrapper } from '@shared/helpers'
 import { getJwkStore } from '@shared/jwt'
+import { RequestExtended } from '@shared/types'
 
-const getJwks = async (_req: Request, res: Response): Promise<Response<unknown>> =>
+const getJwks = async (_req: RequestExtended, res: Response): Promise<Response<unknown>> =>
   res.send(getJwkStore().toJWKS(false))
 
 export default asyncWrapper(getJwks)

--- a/src/routes/auth/login.ts
+++ b/src/routes/auth/login.ts
@@ -19,8 +19,8 @@ interface HasuraData {
 }
 
 async function loginAccount({ body }: Request, res: Response): Promise<unknown> {
-  // useCookie or not
-  const useCookie = body.cookie
+  // default to true
+  const useCookie = typeof body.cookie !== 'undefined' ? body.cookie : true
 
   if (ANONYMOUS_USERS_ENABLE) {
     const { anonymous } = await loginAnonymouslySchema.validateAsync(body)

--- a/src/routes/auth/login.ts
+++ b/src/routes/auth/login.ts
@@ -74,11 +74,8 @@ async function loginAccount({ body }: Request, res: Response): Promise<unknown> 
           refresh_token
         })
       }
-      return
 
-      return res.send({
-        refresh_token
-      })
+      return
     }
   }
 

--- a/src/routes/auth/login.ts
+++ b/src/routes/auth/login.ts
@@ -58,9 +58,25 @@ async function loginAccount({ body }: Request, res: Response): Promise<unknown> 
 
       const refresh_token = await setRefreshToken(res, account.id, useCookie)
 
+      const jwt_token = createHasuraJwt(account)
+      const jwt_expires_in = newJwtExpiry
+
+      // return
+      if (useCookie) {
+        res.send({
+          jwt_token,
+          jwt_expires_in
+        })
+      } else {
+        res.send({
+          jwt_token,
+          jwt_expires_in,
+          refresh_token
+        })
+      }
+      return
+
       return res.send({
-        jwt_token: createHasuraJwt(account),
-        jwt_expires_in: newJwtExpiry,
         refresh_token
       })
     }

--- a/src/routes/auth/mfa/disable.ts
+++ b/src/routes/auth/mfa/disable.ts
@@ -14,6 +14,7 @@ async function disableMfa(req: RequestExtended, res: Response): Promise<unknown>
   }
 
   const { 'user-id': user_id } = req.permission_variables
+
   const { code } = await mfaSchema.validateAsync(req.body)
   const { otp_secret, mfa_enabled } = await selectAccountByUserId(user_id)
 

--- a/src/routes/auth/mfa/enable.ts
+++ b/src/routes/auth/mfa/enable.ts
@@ -1,22 +1,20 @@
-import {
-  asyncWrapper,
-  selectAccountByUserId,
-  getPermissionVariablesFromCookie
-} from '@shared/helpers'
-import { Request, Response } from 'express'
+import { asyncWrapper, selectAccountByUserId } from '@shared/helpers'
+import { Response } from 'express'
 import { updateOtpStatus } from '@shared/queries'
 
 import Boom from '@hapi/boom'
 import { authenticator } from 'otplib'
 import { mfaSchema } from '@shared/validation'
 import { request } from '@shared/request'
+import { RequestExtended } from '@shared/types'
 
-async function enableMfa(req: Request, res: Response): Promise<unknown> {
+async function enableMfa(req: RequestExtended, res: Response): Promise<unknown> {
+  if (!req.permission_variables) {
+    throw Boom.unauthorized('Not logged in')
+  }
+
+  const { 'user-id': user_id } = req.permission_variables
   const { code } = await mfaSchema.validateAsync(req.body)
-
-  const permission_variables = getPermissionVariablesFromCookie(req)
-  const user_id = permission_variables['user-id']
-
   const { otp_secret, mfa_enabled } = await selectAccountByUserId(user_id)
 
   if (mfa_enabled) {

--- a/src/routes/auth/mfa/generate.ts
+++ b/src/routes/auth/mfa/generate.ts
@@ -1,13 +1,18 @@
-import { Request, Response } from 'express'
-import { asyncWrapper, createQR, getPermissionVariablesFromCookie } from '@shared/helpers'
-import { OTP_ISSUER } from '@shared/config'
+import { Response } from 'express'
+import Boom from '@hapi/boom'
 import { authenticator } from 'otplib'
+import { asyncWrapper, createQR } from '@shared/helpers'
+import { OTP_ISSUER } from '@shared/config'
 import { request } from '@shared/request'
 import { updateOtpSecret } from '@shared/queries'
+import { RequestExtended } from '@shared/types'
 
-async function generateMfa(req: Request, res: Response): Promise<unknown> {
-  const permission_variables = getPermissionVariablesFromCookie(req)
-  const user_id = permission_variables['user-id']
+async function generateMfa(req: RequestExtended, res: Response): Promise<unknown> {
+  if (!req.permission_variables) {
+    throw Boom.unauthorized('Not logged in')
+  }
+
+  const { 'user-id': user_id } = req.permission_variables
 
   /**
    * Generate OTP secret and key URI.

--- a/src/routes/auth/mfa/mfa.test.ts
+++ b/src/routes/auth/mfa/mfa.test.ts
@@ -69,3 +69,94 @@ it('should disable mfa for account', async () => {
 
   expect(status).toEqual(204)
 })
+
+describe('MFA without cookies', () => {
+  let jwtToken: string
+
+  // to make sure no cookies are set
+  it('Should logout user', async () => {
+    const { status } = await request.post('/auth/logout')
+    expect(status).toEqual(204)
+  })
+
+  it('Should login without cookies', async () => {
+    const { body, status } = await request
+      .post('/auth/login')
+      .send({ email: account.email, password: account.password, cookie: false })
+    // Save JWT token to globally scoped varaible.
+    jwtToken = body.jwt_token
+
+    expect(status).toEqual(200)
+  })
+
+  it('should generate a secret', async () => {
+    const { body, status } = await request
+      .post('/auth/mfa/generate')
+      .set({ Authorization: `Bearer ${jwtToken}` })
+
+    /**
+     * Save OTP secret to globally scoped variable.
+     */
+    otpSecret = body.otp_secret
+
+    expect(status).toEqual(200)
+
+    expect(body.image_url).toBeString()
+    expect(body.otp_secret).toBeString()
+  })
+
+  it('should enable mfa for account', async () => {
+    const { status } = await request
+      .post('/auth/mfa/enable')
+      .set({ Authorization: `Bearer ${jwtToken}` })
+      .send({ code: authenticator.generate(otpSecret) })
+
+    expect(status).toEqual(204)
+  })
+
+  it('should return a ticket', async () => {
+    const { body, status } = await request
+      .post('/auth/login')
+      .send({ email: account.email, password: account.password })
+
+    /**
+     * Save ticket to globally scoped varaible.
+     */
+    accountTicket = body.ticket
+
+    expect(status).toEqual(200)
+
+    expect(body.mfa).toBeTrue()
+    expect(body.ticket).toBeString()
+  })
+
+  it('should sign the account in (mfa)', async () => {
+    const { body, status } = await request.post('/auth/mfa/totp').send({
+      ticket: accountTicket,
+      code: authenticator.generate(otpSecret),
+      cookie: false
+    })
+
+    /**
+     * Save JWT token to globally scoped varaible.
+     */
+    jwtToken = body.jwt_token
+
+    expect(status).toEqual(200)
+
+    expect(body.jwt_token).toBeString()
+    expect(body.jwt_expires_in).toBeNumber()
+
+    const uuid_regex = /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/
+    expect(body.refresh_token).toMatch(uuid_regex)
+  })
+
+  it('should disable mfa for account', async () => {
+    const { status } = await request
+      .post('/auth/mfa/disable')
+      .set({ Authorization: `Bearer ${jwtToken}` })
+      .send({ code: authenticator.generate(otpSecret) })
+
+    expect(status).toEqual(204)
+  })
+})

--- a/src/routes/auth/mfa/mfa.test.ts
+++ b/src/routes/auth/mfa/mfa.test.ts
@@ -32,7 +32,7 @@ it('should enable mfa for account', async () => {
 it('should return a ticket', async () => {
   const { body, status } = await request
     .post('/auth/login')
-    .send({ email: account.email, password: account.password, cookie: true })
+    .send({ email: account.email, password: account.password })
 
   /**
    * Save ticket to globally scoped varaible.
@@ -48,8 +48,7 @@ it('should return a ticket', async () => {
 it('should sign the account in (mfa)', async () => {
   const { body, status } = await request.post('/auth/mfa/totp').send({
     ticket: accountTicket,
-    code: authenticator.generate(otpSecret),
-    cookie: true
+    code: authenticator.generate(otpSecret)
   })
 
   /**

--- a/src/routes/auth/mfa/mfa.test.ts
+++ b/src/routes/auth/mfa/mfa.test.ts
@@ -32,7 +32,7 @@ it('should enable mfa for account', async () => {
 it('should return a ticket', async () => {
   const { body, status } = await request
     .post('/auth/login')
-    .send({ email: account.email, password: account.password })
+    .send({ email: account.email, password: account.password, cookie: true })
 
   /**
    * Save ticket to globally scoped varaible.
@@ -48,7 +48,8 @@ it('should return a ticket', async () => {
 it('should sign the account in (mfa)', async () => {
   const { body, status } = await request.post('/auth/mfa/totp').send({
     ticket: accountTicket,
-    code: authenticator.generate(otpSecret)
+    code: authenticator.generate(otpSecret),
+    cookie: true
   })
 
   /**

--- a/src/routes/auth/mfa/totp.ts
+++ b/src/routes/auth/mfa/totp.ts
@@ -10,7 +10,9 @@ import { totpSchema } from '@shared/validation'
 async function totpLogin({ body }: Request, res: Response): Promise<void> {
   const { ticket, code } = await totpSchema.validateAsync(body)
   const account = await selectAccount(body)
-  const useCookie = body.cookie
+
+  // default to true
+  const useCookie = typeof body.cookie !== 'undefined' ? body.cookie : true
 
   if (!account) {
     throw Boom.unauthorized('Invalid or expired ticket.')

--- a/src/routes/auth/mfa/totp.ts
+++ b/src/routes/auth/mfa/totp.ts
@@ -7,9 +7,10 @@ import Boom from '@hapi/boom'
 import { authenticator } from 'otplib'
 import { totpSchema } from '@shared/validation'
 
-async function totpLogin({ body }: Request, res: Response): Promise<unknown> {
+async function totpLogin({ body }: Request, res: Response): Promise<void> {
   const { ticket, code } = await totpSchema.validateAsync(body)
   const account = await selectAccount(body)
+  const useCookie = body.cookie
 
   if (!account) {
     throw Boom.unauthorized('Invalid or expired ticket.')
@@ -33,13 +34,24 @@ async function totpLogin({ body }: Request, res: Response): Promise<unknown> {
     throw Boom.unauthorized('Invalid two-factor code.')
   }
 
-  await setRefreshToken(res, id)
+  const refresh_token = await setRefreshToken(res, id, useCookie)
   await rotateTicket(ticket)
+  const jwt_token = createHasuraJwt(account)
+  const jwt_expires_in = newJwtExpiry
 
-  return res.send({
-    jwt_token: createHasuraJwt(account),
-    jwt_expires_in: newJwtExpiry
-  })
+  // return
+  if (useCookie) {
+    res.send({
+      jwt_token,
+      jwt_expires_in
+    })
+  } else {
+    res.send({
+      jwt_token,
+      jwt_expires_in,
+      refresh_token
+    })
+  }
 }
 
 export default asyncWrapper(totpLogin)

--- a/src/routes/auth/providers/utils.ts
+++ b/src/routes/auth/providers/utils.ts
@@ -1,4 +1,4 @@
-import express, { Request, Response, Router } from 'express'
+import express, { Response, Router } from 'express'
 import passport, { Profile } from 'passport'
 import { VerifyCallback } from 'passport-oauth2'
 import { Strategy } from 'passport'
@@ -12,7 +12,13 @@ import {
 } from '@shared/config'
 import { insertAccount, selectAccountProvider } from '@shared/queries'
 import { request } from '@shared/request'
-import { InsertAccountData, QueryAccountProviderData, AccountData, UserData } from '@shared/types'
+import {
+  InsertAccountData,
+  QueryAccountProviderData,
+  AccountData,
+  UserData,
+  RequestExtended
+} from '@shared/types'
 import { setRefreshToken } from '@shared/cookies'
 
 interface Constructable<T> {
@@ -31,7 +37,7 @@ const manageProviderStrategy = (
   provider: string,
   transformProfile: TransformProfileFunction
 ) => async (
-  _req: Request,
+  _req: RequestExtended,
   _accessToken: string,
   _refreshToken: string,
   profile: Profile,
@@ -81,7 +87,7 @@ const manageProviderStrategy = (
   return done(null, hasura_account_provider_data.insert_auth_accounts.returning[0])
 }
 
-const providerCallback = async (req: Request, res: Response): Promise<void> => {
+const providerCallback = async (req: RequestExtended, res: Response): Promise<void> => {
   // Successful authentication, redirect home.
   // generate tokens and redirect back home
 
@@ -91,7 +97,7 @@ const providerCallback = async (req: Request, res: Response): Promise<void> => {
 
   try {
     await setRefreshToken(res, account.id)
-  } catch(e) {
+  } catch (e) {
     res.redirect(PROVIDER_FAILURE_REDIRECT as string)
   }
 

--- a/src/routes/auth/token/refresh.ts
+++ b/src/routes/auth/token/refresh.ts
@@ -3,7 +3,6 @@ import { Response } from 'express'
 import { selectRefreshToken, updateRefreshToken } from '@shared/queries'
 
 import Boom from '@hapi/boom'
-import { COOKIE_SECRET } from '@shared/config'
 import { newJwtExpiry, createHasuraJwt, generatePermissionVariables } from '@shared/jwt'
 import { newRefreshExpiry, setCookie } from '@shared/cookies'
 import { request } from '@shared/request'
@@ -15,6 +14,10 @@ interface HasuraData {
 }
 
 async function refreshToken({ refresh_token }: RequestExtended, res: Response): Promise<void> {
+  if (!refresh_token) {
+    throw Boom.unauthorized('Invalid or expired refresh token.')
+  }
+
   if (!refresh_token.value) {
     throw Boom.unauthorized('Invalid or expired refresh token.')
   }

--- a/src/routes/auth/token/refresh.ts
+++ b/src/routes/auth/token/refresh.ts
@@ -1,5 +1,5 @@
 import { asyncWrapper } from '@shared/helpers'
-import { Request, Response } from 'express'
+import { Response } from 'express'
 import { selectRefreshToken, updateRefreshToken } from '@shared/queries'
 
 import Boom from '@hapi/boom'
@@ -8,22 +8,20 @@ import { newJwtExpiry, createHasuraJwt, generatePermissionVariables } from '@sha
 import { newRefreshExpiry, setCookie } from '@shared/cookies'
 import { request } from '@shared/request'
 import { v4 as uuidv4 } from 'uuid'
-import { AccountData } from '@shared/types'
+import { AccountData, RequestExtended } from '@shared/types'
 
 interface HasuraData {
   auth_refresh_tokens: { account: AccountData }[]
 }
 
-async function refreshToken({ cookies, signedCookies }: Request, res: Response): Promise<unknown> {
-  const { refresh_token } = COOKIE_SECRET ? signedCookies : cookies
-
-  if (!refresh_token) {
+async function refreshToken({ refresh_token }: RequestExtended, res: Response): Promise<void> {
+  if (!refresh_token.value) {
     throw Boom.unauthorized('Invalid or expired refresh token.')
   }
 
   // get account based on refresh token
   const { auth_refresh_tokens } = await request<HasuraData>(selectRefreshToken, {
-    refresh_token,
+    refresh_token: refresh_token.value,
     current_timestamp: new Date()
   })
 
@@ -39,7 +37,7 @@ async function refreshToken({ cookies, signedCookies }: Request, res: Response):
   // and insert new refresh token
   try {
     await request(updateRefreshToken, {
-      old_refresh_token: refresh_token,
+      old_refresh_token: refresh_token.value,
       new_refresh_token_data: {
         account_id: account.id,
         refresh_token: new_refresh_token,
@@ -52,12 +50,22 @@ async function refreshToken({ cookies, signedCookies }: Request, res: Response):
 
   const permission_variables = JSON.stringify(generatePermissionVariables(account))
 
-  setCookie(res, new_refresh_token, permission_variables)
+  const jwt_token = createHasuraJwt(account)
+  const jwt_expires_in = newJwtExpiry
 
-  return res.send({
-    jwt_token: createHasuraJwt(account),
-    jwt_expires_in: newJwtExpiry
-  })
+  if (refresh_token.type === 'cookie') {
+    setCookie(res, new_refresh_token, permission_variables)
+    res.send({
+      jwt_token,
+      jwt_expires_in
+    })
+  } else {
+    res.send({
+      jwt_token,
+      jwt_expires_in,
+      refresh_token: new_refresh_token
+    })
+  }
 }
 
 export default asyncWrapper(refreshToken)

--- a/src/routes/auth/token/revoke.ts
+++ b/src/routes/auth/token/revoke.ts
@@ -1,11 +1,16 @@
-import { Request, Response } from 'express'
-import { asyncWrapper, getPermissionVariablesFromCookie } from '@shared/helpers'
+import { Response } from 'express'
+import Boom from '@hapi/boom'
+import { asyncWrapper } from '@shared/helpers'
 import { deleteAllAccountRefreshTokens } from '@shared/queries'
 import { request } from '@shared/request'
+import { RequestExtended } from '@shared/types'
 
-async function revokeToken(req: Request, res: Response): Promise<unknown> {
-  const permission_variables = getPermissionVariablesFromCookie(req)
-  const user_id = permission_variables['user-id']
+async function revokeToken(req: RequestExtended, res: Response): Promise<unknown> {
+  if (!req.permission_variables) {
+    throw Boom.unauthorized('Not logged in')
+  }
+
+  const { 'user-id': user_id } = req.permission_variables
 
   await request(deleteAllAccountRefreshTokens, { user_id })
 

--- a/src/routes/auth/token/token.test.ts
+++ b/src/routes/auth/token/token.test.ts
@@ -1,6 +1,6 @@
 import 'jest-extended'
 
-import { request } from '@test/test-mock-account'
+import { account, request } from '@test/test-mock-account'
 
 it('should refresh the token', async () => {
   const { body, status } = await request.get('/auth/token/refresh')
@@ -15,4 +15,47 @@ it('should revoke the token', async () => {
   const { status } = await request.post('/auth/token/revoke')
 
   expect(status).toEqual(204)
+})
+
+describe('handle refresh tokens without cookies', () => {
+  let jwtToken: string
+  let refreshToken: string
+
+  // to make sure no cookies are set
+  it('Should logout user', async () => {
+    const { status } = await request.post('/auth/logout')
+    expect(status).toEqual(204)
+  })
+
+  it('Should login user', async () => {
+    const { body, status } = await request
+      .post('/auth/login')
+      .send({ email: account.email, password: account.password, cookie: false })
+
+    // Save refresh token to globally scoped variable.
+    refreshToken = body.refresh_token
+    jwtToken = body.jwt_token
+
+    expect(status).toEqual(200)
+  })
+
+  it('should refresh the token', async () => {
+    const { body, status } = await request
+      .get('/auth/token/refresh')
+      .query({ refresh_token: refreshToken })
+
+    expect(status).toEqual(200)
+
+    expect(body.jwt_token).toBeString()
+    expect(body.jwt_expires_in).toBeNumber()
+    expect(body.refresh_token).toBeString()
+  })
+
+  it('should revoke the token', async () => {
+    const { status } = await request
+      .post('/auth/token/revoke')
+      .set({ Authorization: `Bearer ${jwtToken}` })
+
+    expect(status).toEqual(204)
+  })
 })

--- a/src/routes/storage/delete.ts
+++ b/src/routes/storage/delete.ts
@@ -1,4 +1,4 @@
-import { NextFunction, Request, Response } from 'express'
+import { NextFunction, Response } from 'express'
 import {
   PathConfig,
   createContext,
@@ -11,9 +11,10 @@ import {
 import Boom from '@hapi/boom'
 import { S3_BUCKET } from '@shared/config'
 import { s3 } from '@shared/s3'
+import { RequestExtended } from '@shared/types'
 
 export const deleteFile = async (
-  req: Request,
+  req: RequestExtended,
   res: Response,
   _next: NextFunction,
   rules: Partial<PathConfig>,

--- a/src/routes/storage/get.ts
+++ b/src/routes/storage/get.ts
@@ -1,12 +1,13 @@
-import { NextFunction, Request, Response } from 'express'
+import { NextFunction, Response } from 'express'
 import { PathConfig, createContext, getHeadObject, getKey, hasPermission } from './utils'
 
 import Boom from '@hapi/boom'
 import { S3_BUCKET } from '@shared/config'
 import { s3 } from '@shared/s3'
+import { RequestExtended } from '@shared/types'
 
 export const getFile = async (
-  req: Request,
+  req: RequestExtended,
   res: Response,
   _next: NextFunction,
   rules: Partial<PathConfig>,

--- a/src/routes/storage/index.ts
+++ b/src/routes/storage/index.ts
@@ -1,8 +1,9 @@
 import { OBJECT_PREFIX, META_PREFIX, STORAGE_RULES, PathConfig, containsSomeRule } from './utils'
-import { NextFunction, Request, Response, Router } from 'express'
+import { NextFunction, Response, Router } from 'express'
 import { deleteFile } from './delete'
 import { listGet } from './list_get'
 import { uploadFile } from './upload'
+import { RequestExtended } from '@shared/types'
 
 const router = Router()
 
@@ -10,7 +11,7 @@ const createSecureMiddleware = (
   fn: Function,
   rules: Partial<PathConfig>,
   isMetadataRequest: boolean
-) => (req: Request, res: Response, next: NextFunction): void =>
+) => (req: RequestExtended, res: Response, next: NextFunction): void =>
   fn(req, res, next, rules, isMetadataRequest, rules.metadata).catch(next)
 
 const createRoutes = (

--- a/src/routes/storage/list.ts
+++ b/src/routes/storage/list.ts
@@ -1,13 +1,14 @@
-import { NextFunction, Request, Response } from 'express'
+import { NextFunction, Response } from 'express'
 import { PathConfig, createContext, getKey, hasPermission } from './utils'
 
 import Boom from '@hapi/boom'
 import { S3_BUCKET } from '@shared/config'
 import archiver from 'archiver'
 import { s3 } from '@shared/s3'
+import { RequestExtended } from '@shared/types'
 
 export const listFile = async (
-  req: Request,
+  req: RequestExtended,
   res: Response,
   _next: NextFunction,
   rules: Partial<PathConfig>,

--- a/src/routes/storage/list_get.ts
+++ b/src/routes/storage/list_get.ts
@@ -1,10 +1,11 @@
-import { NextFunction, Request, Response } from 'express'
+import { NextFunction, Response } from 'express'
 import { PathConfig, getKey } from './utils'
 import { getFile } from './get'
 import { listFile } from './list'
+import { RequestExtended } from '@shared/types'
 
 export const listGet = async (
-  req: Request,
+  req: RequestExtended,
   res: Response,
   _next: NextFunction,
   rules: Partial<PathConfig>,

--- a/src/routes/storage/storage.test.ts
+++ b/src/routes/storage/storage.test.ts
@@ -65,7 +65,9 @@ describe('Tests as an unauthenticated user', () => {
   })
 
   afterAll(async () => {
-    await request.post('/auth/login').send({ email: account.email, password: account.password })
+    await request
+      .post('/auth/login')
+      .send({ email: account.email, password: account.password, cookie: true })
   })
 
   it('should get file from the token stored in the file metadata while unauthenticated', async () => {
@@ -99,14 +101,11 @@ describe('Tests as an unauthenticated user', () => {
 // })
 
 it('should get file metadata', async () => {
-  const {
-    status,
-    body: {
-      Metadata: { token }
-    }
-  } = await request.get(`/storage/m/user/${getUserId()}/${filePath}`)
+  const { status, body } = await request.get(`/storage/m/user/${getUserId()}/${filePath}`)
+  console.log('should get file metadata log body:')
+  console.log(body)
   expect(status).toEqual(200)
-  expect(token).toEqual(fileToken)
+  expect(body.Metadata.token).toEqual(fileToken)
 })
 
 it('should get the headers of all the user files', async () => {

--- a/src/routes/storage/upload.ts
+++ b/src/routes/storage/upload.ts
@@ -1,4 +1,4 @@
-import { NextFunction, Request, Response } from 'express'
+import { NextFunction, Response } from 'express'
 import { v4 as uuidv4 } from 'uuid'
 import { PathConfig, createContext, getHeadObject, getKey, hasPermission } from './utils'
 
@@ -6,9 +6,10 @@ import Boom from '@hapi/boom'
 import { S3_BUCKET } from '@shared/config'
 import { UploadedFile } from 'express-fileupload'
 import { s3 } from '@shared/s3'
+import { RequestExtended } from '@shared/types'
 
 export const uploadFile = async (
-  req: Request,
+  req: RequestExtended,
   res: Response,
   _next: NextFunction,
   rules: Partial<PathConfig>,

--- a/src/routes/storage/utils.ts
+++ b/src/routes/storage/utils.ts
@@ -3,14 +3,12 @@ import { v4 as uuidv4 } from 'uuid'
 
 import Boom from '@hapi/boom'
 import { HeadObjectOutput } from 'aws-sdk/clients/s3'
-import { Request } from 'express'
 import { S3_BUCKET } from '@shared/config'
 import fs from 'fs'
 import path from 'path'
 import { s3 } from '@shared/s3'
 import yaml from 'js-yaml'
-import { PermissionVariables } from '@shared/types'
-import { getPermissionVariablesFromCookie } from '@shared/helpers'
+import { PermissionVariables, RequestExtended } from '@shared/types'
 
 export const OBJECT_PREFIX = '/o'
 export const META_PREFIX = '/m'
@@ -81,15 +79,10 @@ const storageFunctions = (context: object): { [key: string]: Function } =>
   }, {})
 
 export const createContext = (
-  req: Request,
+  req: RequestExtended,
   s3HeadObject: object = {} // TODO better s3 head object type
 ): object => {
-  let auth
-  try {
-    auth = getPermissionVariablesFromCookie(req)
-  } catch (err) {
-    auth = undefined
-  }
+  const auth = req.permission_variables
 
   const variables: StorageContext = {
     request: {
@@ -125,10 +118,10 @@ export const generateMetadata = (metadataParams: object, context: object): objec
   }, {})
 
 // Creates an object key that is the path without the first character '/'
-export const getKey = (req: Request): string => req.path.substring(1)
+export const getKey = (req: RequestExtended): string => req.path.substring(1)
 
 export const getHeadObject = async (
-  req: Request,
+  req: RequestExtended,
   ignoreErrors = false
 ): Promise<HeadObjectOutput | undefined> => {
   const params = {
@@ -146,7 +139,7 @@ export const getHeadObject = async (
 }
 
 export const replaceMetadata = async (
-  req: Request,
+  req: RequestExtended,
   keepOldMetadata: boolean,
   newMetadata: object = {}
 ): Promise<void> => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,6 +10,7 @@ import morgan from 'morgan'
 import { limiter } from './limiter'
 import router from './routes'
 import passport from 'passport'
+import { authMiddleware } from './middlewares/auth'
 
 const app = express()
 
@@ -36,6 +37,7 @@ if (COOKIE_SECRET) {
   app.use(cookieParser())
 }
 
+app.use(authMiddleware)
 app.use(router)
 app.use(errors)
 

--- a/src/shared/cookies.ts
+++ b/src/shared/cookies.ts
@@ -56,16 +56,18 @@ export const setCookie = (
 }
 
 /**
- * Insert new refresh token in database and set new refresh token as cookie.
+ * Insert new refresh token in database and maybe set new refresh token as cookie.
  * @param res Express Response
  * @param accountId Account ID
+ * @param useCookie (optional) if the cookie should be set or not
  * @param refresh_token (optional) Refresh token to be set
  */
 export const setRefreshToken = async (
   res: Response,
   accountId: string,
+  useCookie = false,
   refresh_token?: string
-): Promise<void> => {
+): Promise<string> => {
   if (!refresh_token) {
     refresh_token = uuidv4()
   }
@@ -78,9 +80,14 @@ export const setRefreshToken = async (
     }
   })) as InsertRefreshTokenData
 
-  const { account } = insert_account_data.insert_auth_refresh_tokens_one
+  if (useCookie) {
+    const { account } = insert_account_data.insert_auth_refresh_tokens_one
+    const permission_variables = JSON.stringify(generatePermissionVariables(account))
+    setCookie(res, refresh_token, permission_variables)
+  } else {
+    res.clearCookie('refresh_token')
+    res.clearCookie('permission_variables')
+  }
 
-  const permission_variables = JSON.stringify(generatePermissionVariables(account))
-
-  setCookie(res, refresh_token, permission_variables)
+  return refresh_token
 }

--- a/src/shared/helpers.ts
+++ b/src/shared/helpers.ts
@@ -1,5 +1,5 @@
 import { HIBP_ENABLE, COOKIE_SECRET } from './config'
-import { NextFunction, Request, Response } from 'express'
+import { NextFunction, Response } from 'express'
 import {
   rotateTicket as rotateTicketQuery,
   selectAccountByEmail as selectAccountByEmailQuery,
@@ -13,7 +13,7 @@ import bcrypt from 'bcryptjs'
 import { pwnedPassword } from 'hibp'
 import { request } from './request'
 import { v4 as uuidv4 } from 'uuid'
-import { AccountData, QueryAccountData, PermissionVariables } from './types'
+import { AccountData, QueryAccountData, PermissionVariables, RequestExtended } from './types'
 
 /**
  * Create QR code.
@@ -32,7 +32,7 @@ export async function createQR(secret: string): Promise<string> {
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function asyncWrapper(fn: any) {
-  return function (req: Request, res: Response, next: NextFunction): void {
+  return function (req: RequestExtended, res: Response, next: NextFunction): void {
     fn(req, res, next).catch(next)
   }
 }
@@ -113,7 +113,7 @@ export const rotateTicket = async (ticket: string): Promise<string> => {
   return new_ticket
 }
 
-export const getPermissionVariablesFromCookie = (req: Request): PermissionVariables => {
+export const getPermissionVariablesFromCookie = (req: RequestExtended): PermissionVariables => {
   const { permission_variables } = COOKIE_SECRET ? req.signedCookies : req.cookies
   if (!permission_variables) throw Boom.unauthorized()
   return JSON.parse(permission_variables)

--- a/src/shared/request.ts
+++ b/src/shared/request.ts
@@ -25,6 +25,7 @@ export async function request<T extends unknown>(
   try {
     return (await client.request(print(query), variables)) as T
   } catch (err) {
+    console.error(err)
     throw Boom.badImplementation()
   }
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -100,6 +100,6 @@ export interface RefreshTokenMiddleware {
 }
 
 export interface RequestExtended extends Request {
-  refresh_token: RefreshTokenMiddleware
-  permission_variables: PermissionVariables
+  refresh_token?: RefreshTokenMiddleware
+  permission_variables?: PermissionVariables
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,3 +1,6 @@
+import { string } from '@hapi/joi'
+import { Request } from 'express'
+
 export type ClaimValueType =
   | string
   | string[]
@@ -89,4 +92,13 @@ export interface InsertAccountData {
   insert_auth_accounts: {
     returning: AccountData[]
   }
+}
+
+export interface RefreshTokenMiddleware {
+  value: string | null
+  type: 'query' | 'cookie' | null
+}
+
+export interface RequestExtended extends Request {
+  refresh_token: RefreshTokenMiddleware
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,4 +1,3 @@
-import { string } from '@hapi/joi'
 import { Request } from 'express'
 
 export type ClaimValueType =

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -101,4 +101,5 @@ export interface RefreshTokenMiddleware {
 
 export interface RequestExtended extends Request {
   refresh_token: RefreshTokenMiddleware
+  permission_variables: PermissionVariables
 }

--- a/src/shared/validation.ts
+++ b/src/shared/validation.ts
@@ -102,7 +102,10 @@ export const loginAnonymouslySchema = Joi.object({
   email: Joi.string(), // these will be checked more regeriously in `loginSchema`
   password: Joi.string() // these will be checked more regeriously in `loginSchema`
 })
-export const loginSchema = extendedJoi.object(accountFields)
+export const loginSchema = extendedJoi.object({
+  ...accountFields,
+  cookie: Joi.boolean()
+})
 export const forgotSchema = Joi.object({ email: emailRule })
 export const verifySchema = Joi.object({ ...ticketFields })
 export const totpSchema = Joi.object({ ...codeFields, ...ticketFields })

--- a/src/shared/validation.ts
+++ b/src/shared/validation.ts
@@ -108,4 +108,8 @@ export const loginSchema = extendedJoi.object({
 })
 export const forgotSchema = Joi.object({ email: emailRule })
 export const verifySchema = Joi.object({ ...ticketFields })
-export const totpSchema = Joi.object({ ...codeFields, ...ticketFields })
+export const totpSchema = Joi.object({
+  ...codeFields,
+  ...ticketFields,
+  cookie: Joi.boolean()
+})

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -98,7 +98,7 @@ export const registerAccount = async (agent: SuperTest<Test>): Promise<TestAccou
     await agent.get(`/auth/activate?ticket=${ticket}`)
     await deleteEmailsOfAccount(email)
   }
-  const res = await agent.post('/auth/login').send({ email, password })
+  const res = await agent.post('/auth/login').send({ email, password, cookie: true })
   // * Set the use variable so it is accessible to the jest test file
   return {
     email,

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -98,7 +98,7 @@ export const registerAccount = async (agent: SuperTest<Test>): Promise<TestAccou
     await agent.get(`/auth/activate?ticket=${ticket}`)
     await deleteEmailsOfAccount(email)
   }
-  const res = await agent.post('/auth/login').send({ email, password, cookie: true })
+  const res = await agent.post('/auth/login').send({ email, password })
   // * Set the use variable so it is accessible to the jest test file
   return {
     email,


### PR DESCRIPTION
Since cookies do not always play well with mobile app development we'll introduce a non-cookie strategy alongside the current cookie strategy for handling `refresh_token` and `permission_variables`.

- [x] login
- [x] refresh token
- [x] TOTP
- [x] permission variables