### PR TITLE
Update get.ts

### DIFF
--- a/src/routes/storage/get.ts
+++ b/src/routes/storage/get.ts
@@ -43,11 +43,11 @@ export const getFile = async (
       Key: key,
       Range: range
     }
-    const stream = s3.getObject(params).createReadStream()
-    // forward errors
-    stream.on('error', (err) => {
+    // Split request with stream to be able to abort request on timeout errors
+    const request = s3.getObject(params)
+    const stream = request.createReadStream().on('error', (err) => {
       console.error(err)
-      throw Boom.badImplementation()
+      request.abort()
     })
 
     // Add the content type to the response (it's not propagated from the S3 SDK)


### PR DESCRIPTION
Adapted handling of errors on getObject from S3 minio storage so that timeout errors don't restart the entire HBP instance. Timeout errors come from the client starting but not finishing a download, e.g. when scrolling fast through a flatlist on React Native (only elements in view are being rendered, causing elements that are scrolled past sometimes being requested but never rendered).