### PR TITLE
Allow for a different SMTP sender

### DIFF
--- a/src/shared/config/application.ts
+++ b/src/shared/config/application.ts
@@ -32,7 +32,7 @@ export const {
   SMTP_PASS,
   SMTP_HOST,
   SMTP_USER,
-  SMTP_SENDER = SMTP_USER,
+  SMTP_SENDER,
   SMTP_AUTH_METHOD = 'PLAIN'
 } = process.env
 export const EMAILS_ENABLE = castBooleanEnv('EMAILS_ENABLE')


### PR DESCRIPTION
- The configuration for SMTP assumes that the `SMTP_SENDER` is always the same as the `SMTP_USER`, which is not always the case.