### PR TITLE
use email if display_name is null from OAuth provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - server: `display_name` is attached for email templates
 - server: Added auth middleware to support non-cookie approach for refresh and JWT tokens
+- server: Default to email if no display_name exists for OAuth Provider.
 
 ## v2.1.1
 

--- a/src/routes/auth/providers/utils.ts
+++ b/src/routes/auth/providers/utils.ts
@@ -69,7 +69,7 @@ const manageProviderStrategy = (
     account_roles: {
       data: [{ role: DEFAULT_USER_ROLE }]
     },
-    user: { data: { display_name, avatar_url } },
+    user: { data: { display_name: display_name || email, avatar_url } },
     account_providers: {
       data: [
         {


### PR DESCRIPTION
Fixes https://github.com/nhost/hasura-backend-plus/issues/342