### PR TITLE
Fixed example docker-compose.yml

### DIFF
--- a/examples/simple-hasura-minio/docker-compose.yaml
+++ b/examples/simple-hasura-minio/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
       HASURA_GRAPHQL_DATABASE_URL: postgres://postgres:postgrespassword@postgres:5432/postgres
       HASURA_GRAPHQL_ADMIN_SECRET: '$HASURA_GRAPHQL_ADMIN_SECRET'
       HASURA_GRAPHQL_JWT_SECRET: '{"type": "RS256", "jwk_url": "http://hasura-backend-plus:3000/auth/jwks"}'
-      HASURA_GRAPHQL_ENABLE_CONSOLE: true
+      HASURA_GRAPHQL_ENABLE_CONSOLE: 'true'
   hasura-backend-plus:
     image: nhost/hasura-backend-plus:latest
     ports:
@@ -32,7 +32,7 @@ services:
       S3_BUCKET: hasura-backend-plus
       S3_ACCESS_KEY_ID: minio_access_key
       S3_SECRET_ACCESS_KEY: '${S3_SECRET_ACCESS_KEY:?S3_SECRET_ACCESS_KEY}'
-      AUTO_MIGRATE: true
+      AUTO_MIGRATE: 'true'
   minio:
     image: minio/minio
     restart: always

--- a/examples/simple-hasura-minio/docker-compose.yaml
+++ b/examples/simple-hasura-minio/docker-compose.yaml
@@ -23,6 +23,7 @@ services:
     image: nhost/hasura-backend-plus:latest
     ports:
       - '3000:3000'
+    restart: always
     environment:
       SERVER_URL: http://localhost:3000
       HASURA_ENDPOINT: http://graphql-engine:8080/v1/graphql


### PR DESCRIPTION
The example docker compose example doesn't work on my machine due to boolean being used in the environment variables section.

> Any boolean values; true, false, yes, no, MUST be enclosed in quotes to ensure they are not converted to True or False by the YAML parser.

Source: https://github.com/compose-spec/compose-spec/blob/master/spec.md#environment

Error:

```
ERROR: The Compose file '.\docker-compose.yml' is invalid because:
services.graphql-engine.environment.HASURA_GRAPHQL_ENABLE_CONSOLE contains true, which is an invalid type, it should be a string, number, or a null
services.hasura-backend-plus.environment.AUTO_MIGRATE contains true, which is an invalid type, it should be a string, number, or a null
```

docker-compose version 1.27.4, build 40524192