### PR TITLE
[bugfix] Add cookie to registerSchema

### DIFF
--- a/src/shared/validation.ts
+++ b/src/shared/validation.ts
@@ -69,7 +69,8 @@ export const userDataFields = {
 
 export const registerSchema = Joi.object({
   ...accountFields,
-  ...userDataFields
+  ...userDataFields,
+  cookie: Joi.boolean()
 })
 
 export const registerUserDataSchema = Joi.object(userDataFields)


### PR DESCRIPTION
- `refresh_token` is not being returned because `cookie` is not allowed to be sent from the SDK and it defaults to `true` here on HBP