### PR TITLE
optional REFRESH_COOKIE_NAME environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -187,3 +187,7 @@ S3_ENDPOINT=
 S3_BUCKET=
 S3_ACCESS_KEY_ID=
 S3_SECRET_ACCESS_KEY=
+
+################### Cookies options ###################
+## Customize name of Cookie sent to refresh endpoint
+# REFRESH_COOKIE_NAME='refresh_token'

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -1,5 +1,5 @@
 import { Response, NextFunction } from 'express'
-import { COOKIE_SECRET } from '@shared/config'
+import { COOKIE_SECRET, REFRESH_COOKIE_NAME } from '@shared/config'
 import { RefreshTokenMiddleware, RequestExtended, PermissionVariables, Claims } from '@shared/types'
 import { getClaims } from '@shared/jwt'
 import { getPermissionVariablesFromCookie } from '@shared/helpers'
@@ -46,9 +46,9 @@ export function authMiddleware(req: RequestExtended, res: Response, next: NextFu
   // -------------------------------------
   const cookiesInUse = COOKIE_SECRET ? req.signedCookies : req.cookies
 
-  if ('refresh_token' in cookiesInUse) {
+  if (`${REFRESH_COOKIE_NAME}` in cookiesInUse) {
     refresh_token = {
-      value: cookiesInUse.refresh_token,
+      value: cookiesInUse[`${REFRESH_COOKIE_NAME}`],
       type: 'cookie'
     }
     req.refresh_token = refresh_token

--- a/src/shared/config/authentication/cookies.ts
+++ b/src/shared/config/authentication/cookies.ts
@@ -1,6 +1,7 @@
 import { castBooleanEnv } from '../utils'
 
 export const { COOKIE_SECRET } = process.env
+export const { REFRESH_COOKIE_NAME = 'refresh_token' } = process.env
 export const COOKIE_SECURE = castBooleanEnv('COOKIE_SECURE')
 
 const sameSiteEnv = process.env.COOKIE_SAME_SITE?.toLowerCase()


### PR DESCRIPTION
Hello

I'm working on a boilerplate for NuxtJS - Hasura-Backend-Plus - Hasura.

NuxtJS auth module has now a "Refresh scheme", but the cookie submitted is by default `auth._refresh_token.local` and cannot be set to `refresh_token` like expected by HBP.

REFRESH_COOKIE_NAME optionnal env var will allow a custom cookie name on /auth/token/refresh

Thanks