### PR TITLE
Add option for rounded images

### DIFF
--- a/src/routes/storage/get.ts
+++ b/src/routes/storage/get.ts
@@ -56,11 +56,21 @@ export const getFile = async (
   
       // Add corners to the image when the radius ('r') is is specified in the query
       if (r) {
-        const { height, width } = await transformer.metadata()
-        const radiusX = r === 'full' ? height : r
-        const radiusY = r === 'full' ? width : r
-        const overlay = new Buffer(`<svg><rect x="0" y="0" width="${width}" height="${height}" rx="${radiusX}" ry="${radiusY}"/></svg>`)
-        transformer.overlayWith(overlay, { cutout: true }) 
+        let { height, width } = await transformer.metadata()
+        if (w && h) {
+          width = w
+          height = h
+        } else if (w) {
+          height = Math.round(height * w / width)
+          width = w
+        } else if (h) {
+          width = Math.round(width * h / height)
+          height = h
+        }
+
+        // Set the radius to 'r' or to 1/2 the height or width
+        const radius = r === 'full' ? Math.min(height, width) / 2 : r
+        const overlay = Buffer.from(`<svg><rect x="0" y="0" width="${width}" height="${height}" rx="${radius}" ry="${radius}"/></svg>`)
         transformer.composite([{ input: overlay, blend: 'dest-in' }])
       }
 

--- a/src/routes/storage/get.ts
+++ b/src/routes/storage/get.ts
@@ -61,6 +61,7 @@ export const getFile = async (
         const radiusY = r === 'full' ? width : r
         const overlay = new Buffer(`<svg><rect x="0" y="0" width="${width}" height="${height}" rx="${radiusX}" ry="${radiusY}"/></svg>`)
         transformer.overlayWith(overlay, { cutout: true }) 
+        transformer.composite([{ input: overlay, blend: 'dest-in' }])
       }
 
       if (contentType === WEBP) {

--- a/src/routes/storage/get.ts
+++ b/src/routes/storage/get.ts
@@ -70,7 +70,8 @@ export const getFile = async (
         }
 
         // Set the radius to 'r' or to 1/2 the height or width
-        const radius = r === 'full' ? Math.min(height, width) / 2 : r
+        const maxRadius = Math.min(height, width) / 2
+        const radius = r === 'full' ? maxRadius : Math.min(maxRadius, r)
         const overlay = Buffer.from(`<svg><rect x="0" y="0" width="${width}" height="${height}" rx="${radius}" ry="${radius}"/></svg>`)
         transformer.composite([{ input: overlay, blend: 'dest-in' }])
       }

--- a/src/routes/storage/get.ts
+++ b/src/routes/storage/get.ts
@@ -30,7 +30,7 @@ export const getFile = async (
   if (isMetadataRequest) {
     return res.status(200).send({ key, ...headObject })
   } else {
-    if (req.query.w || req.query.h || req.query.q) {
+    if (req.query.w || req.query.h || req.query.q || req.query.r) {
       // transform image
       const { w, h, q, r } = await imgTransformParams.validateAsync(req.query)
 

--- a/src/routes/storage/get.ts
+++ b/src/routes/storage/get.ts
@@ -55,7 +55,8 @@ export const getFile = async (
       transformer.resize({ width: w, height: h })
   
       // Add corners to the image when the radius ('r') is is specified in the query
-      if (r) {
+      let { height, width } = await transformer.metadata()
+      if (r && height && width) {
         let { height, width } = await transformer.metadata()
         if (w && h) {
           width = w


### PR DESCRIPTION
Many images (especially avatars) are rounded. By adding the option to remove the parts outside a given radius the size of the image can be minified without compromising the quality. Especially for full rounded images this can be significant, removing over 20% of the image.