### PR TITLE
Add the ability to specify the format of the image

### DIFF
--- a/src/routes/storage/get.ts
+++ b/src/routes/storage/get.ts
@@ -44,7 +44,7 @@ export const getFile = async (
       }
       
       // Find and set the contentType
-      const acceptsWebP = req.headers.accept.split(',').some(header => header === WEBP)
+      const acceptsWebP = !!req?.headers?.accept?.split(',').some(header => header === WEBP)
       const contentType = f
         ? f === 'auto'
           ? acceptsWebP

--- a/src/shared/validation.ts
+++ b/src/shared/validation.ts
@@ -123,6 +123,12 @@ export const imgTransformParams = Joi.object({
   w: Joi.number().integer().min(0).max(8192),
   h: Joi.number().integer().min(0).max(8192),
   q: Joi.number().integer().min(0).max(100).default(100),
+  f: Joi.alternatives().try(
+    Joi.string().valid('webp'),
+    Joi.string().valid('png'),
+    Joi.string().valid('jpeg'),
+    Joi.string().valid('auto')
+  ),
   token: Joi.string().uuid()
 })
 


### PR DESCRIPTION
Add an 'f' parameter which will set the contentType. This parameter can be either one of 'png', 'jpeg', 'webp', or 'auto'.

The auto parameter will look at the accept headers, if the browser accepts webp, it will use that, otherwise it will return the contentType of the image itself.