### PR TITLE
Use JWT_KEY_FILE_PATH if available

### DIFF
--- a/src/shared/config/authentication/jwt.ts
+++ b/src/shared/config/authentication/jwt.ts
@@ -7,9 +7,9 @@ import { castIntEnv, castStringArrayEnv } from '../utils'
 export const {
   JWT_KEY,
   JWT_ALGORITHM = 'RS256',
-  JWT_CLAIMS_NAMESPACE = 'https://hasura.io/jwt/claims'
-} = process.env
-export const JWT_KEY_FILE_PATH = path.resolve(process.env.PWD || '.', 'custom/keys/private.pem')
+  JWT_CLAIMS_NAMESPACE = 'https://hasura.io/jwt/claims',
+  JWT_KEY_FILE_PATH = path.resolve(process.env.PWD || '.', 'custom/keys/private.pem'),
+} = process.env;
 export const JWT_EXPIRES_IN = castIntEnv('JWT_EXPIRES_IN', 15)
 export const JWT_REFRESH_EXPIRES_IN = castIntEnv('JWT_REFRESH_EXPIRES_IN', 43200)
 export const JWT_CUSTOM_FIELDS = castStringArrayEnv('JWT_CUSTOM_FIELDS')


### PR DESCRIPTION
While the README had you set the JWT_KEY_FILE_PATH, it was being ignored
when the code was loading.

This fixes that to use the environment variable and fallback on a
default path if needed.