### PR TITLE
Presigned urls

### DIFF
--- a/src/routes/storage/get_presigned.ts
+++ b/src/routes/storage/get_presigned.ts
@@ -1,0 +1,48 @@
+import { NextFunction, Response } from 'express'
+import { PathConfig, createContext, getHeadObject, getKey, hasPermission } from './utils'
+
+import Boom from '@hapi/boom'
+import { S3_BUCKET, S3_PRESIGNED_URL_EXPIRES_DEFAULT } from '@shared/config'
+import { s3 } from '@shared/s3'
+import { RequestExtended } from '@shared/types'
+import { filePresignedParms } from '@shared/validation'
+
+export const getFilePresignedURL = async (
+  req: RequestExtended,
+  res: Response,
+  _next: NextFunction,
+  rules: Partial<PathConfig>
+): Promise<unknown> => {
+  const key = getKey(req)
+  const headObject = await getHeadObject(req)
+  if (!headObject?.Metadata) {
+    throw Boom.forbidden()
+  }
+
+  const context = createContext(req, headObject)
+
+  if (!hasPermission([rules.get, rules.read], context)) {
+    throw Boom.forbidden()
+  }
+
+  let expires = S3_PRESIGNED_URL_EXPIRES_DEFAULT;
+
+  if (req.query.expires) {
+    const { expires: e } = await filePresignedParms.validateAsync(req.query);
+    expires = e;
+  }
+  const params = {
+    Bucket: S3_BUCKET as string,
+    Key: key,
+    Expires: expires
+  }
+
+  try {
+    const url = await s3.getSignedUrlPromise('getObject', params)
+    return res.status(200).send({ key, url })
+  } catch (err) {
+    console.error('Fail to generate presigned PUT URL')
+    console.error(err)
+    throw Boom.badImplementation('Fail to generate presigned PUR URL')
+  }
+}

--- a/src/routes/storage/list_get.ts
+++ b/src/routes/storage/list_get.ts
@@ -1,6 +1,7 @@
 import { NextFunction, Response } from 'express'
 import { PathConfig, getKey } from './utils'
 import { getFile } from './get'
+import { getFilePresignedURL } from './get_presigned'
 import { listFile } from './list'
 import { RequestExtended } from '@shared/types'
 
@@ -9,7 +10,8 @@ export const listGet = async (
   res: Response,
   _next: NextFunction,
   rules: Partial<PathConfig>,
-  isMetadataRequest = false
+  isMetadataRequest = false,
+  isPresignedRequest = false
 ): Promise<unknown> => {
   const key = getKey(req)
 
@@ -19,5 +21,9 @@ export const listGet = async (
   }
 
   // or get file
+  if (isPresignedRequest) {
+    return getFilePresignedURL(req, res, _next, rules)
+  }
+
   return getFile(req, res, _next, rules, isMetadataRequest)
 }

--- a/src/routes/storage/storage.test.ts
+++ b/src/routes/storage/storage.test.ts
@@ -140,6 +140,13 @@ describe('Tests as an unauthenticated user', () => {
     expect(text).toEqual(fileData)
   })
 
+  it('should get file presigned url from the token stored in the file metadata while unauthenticated', async () => {
+    const { status } = await request
+      .get(`/storage/presign/user/${getUserId()}/${filePath}`)
+      .query({ token: fileToken })
+    expect(status).toEqual(200)
+  })
+
   it('should not get file from incorrect token while unauthenticated', async () => {
     const { status } = await request
       .get(`/storage/o/user/${getUserId()}/${filePath}`)
@@ -149,6 +156,11 @@ describe('Tests as an unauthenticated user', () => {
 
   it('should not get file without authentication nor token', async () => {
     const { status } = await request.get(`/storage/o/user/${getUserId()}/${filePath}`)
+    expect(status).toEqual(403)
+  })
+
+  it('should not get file presigned without authentication nor token', async () => {
+    const { status } = await request.get(`/storage/presign/user/${getUserId()}/${filePath}`)
     expect(status).toEqual(403)
   })
   // TODO attempt to get the file from another authenticated user

--- a/src/routes/storage/upload_presigned.ts
+++ b/src/routes/storage/upload_presigned.ts
@@ -56,6 +56,6 @@ export const uploadFilePresignedURL = async (
     console.error('Fail to generate presigned PUT URL')
     console.error({ params })
     console.error(err)
-    throw Boom.badImplementation('Fail to generate presigned PUR URL')
+    throw Boom.badImplementation('Fail to generate presigned PUT URL')
   }
 }

--- a/src/routes/storage/upload_presigned.ts
+++ b/src/routes/storage/upload_presigned.ts
@@ -1,0 +1,61 @@
+import { NextFunction, Response } from 'express'
+import { v4 as uuidv4 } from 'uuid'
+import { PathConfig, createContext, getHeadObject, getKey, hasPermission } from './utils'
+
+import Boom from '@hapi/boom'
+import { S3_BUCKET, S3_PRESIGNED_URL_EXPIRES_DEFAULT } from '@shared/config'
+import { s3 } from '@shared/s3'
+import { RequestExtended } from '@shared/types'
+import { filePresignedParms } from '@shared/validation'
+
+export const uploadFilePresignedURL = async (
+  req: RequestExtended,
+  res: Response,
+  _next: NextFunction,
+  rules: Partial<PathConfig>
+): Promise<unknown> => {
+  const key = getKey(req)
+
+  if (key.endsWith('/')) {
+    throw Boom.forbidden(`Can't upload file that ends with /`)
+  }
+
+  const oldHeadObject = await getHeadObject(req, true)
+  const isNew = !oldHeadObject
+
+  const context = createContext(req, oldHeadObject)
+
+  if (!hasPermission(isNew ? [rules.create, rules.write] : [rules.update, rules.write], context)) {
+    throw Boom.forbidden()
+  }
+
+  let expires = S3_PRESIGNED_URL_EXPIRES_DEFAULT
+
+  if (req.body.expires) {
+    const { expires: e } = await filePresignedParms.validateAsync(req.body)
+    expires = e
+  }
+
+  // Generate PreSigned URL
+  const params = {
+    Bucket: S3_BUCKET as string,
+    Key: key,
+    Expires: expires,
+    Metadata: {
+      token: oldHeadObject?.Metadata?.token || uuidv4()
+    }
+  }
+
+  try {
+    const url = await s3.getSignedUrlPromise('putObject', params)
+    return res.status(200).send({
+      key,
+      url
+    })
+  } catch (err) {
+    console.error('Fail to generate presigned PUT URL')
+    console.error({ params })
+    console.error(err)
+    throw Boom.badImplementation('Fail to generate presigned PUR URL')
+  }
+}

--- a/src/routes/storage/utils.ts
+++ b/src/routes/storage/utils.ts
@@ -12,6 +12,7 @@ import { PermissionVariables, RequestExtended } from '@shared/types'
 
 export const OBJECT_PREFIX = '/o'
 export const META_PREFIX = '/m'
+export const PRESIGN_PREFIX = '/presign'
 export interface PathConfig {
   read: string
   write: string

--- a/src/shared/config/storage.ts
+++ b/src/shared/config/storage.ts
@@ -1,8 +1,15 @@
-import { castBooleanEnv } from './utils'
+import { castBooleanEnv, castIntEnv } from './utils'
 
 /**
  * * Storage Settings
  */
 export const STORAGE_ENABLE = castBooleanEnv('STORAGE_ENABLE', true)
 export const S3_SSL_ENABLED = castBooleanEnv('S3_SSL_ENABLED', true)
+
+// Default Presigned URL expiries to 24 hours
+export const S3_PRESIGNED_URL_EXPIRES_DEFAULT = castIntEnv(
+  'S3_PRESIGNED_URL_EXPIRES_DEFAULT',
+  60 * 60 * 24
+)
+
 export const { S3_BUCKET, S3_ENDPOINT, S3_ACCESS_KEY_ID, S3_SECRET_ACCESS_KEY } = process.env

--- a/src/shared/validation.ts
+++ b/src/shared/validation.ts
@@ -133,3 +133,7 @@ export const fileMetadataUpdate = Joi.object({
   // action: Joi.string().valid('revoke-token','some-other-action').required(),
   action: Joi.string().valid('revoke-token').required()
 })
+
+export const filePresignedParms = Joi.object({
+  expires: Joi.number().integer().min(1)
+})

--- a/src/shared/validation.ts
+++ b/src/shared/validation.ts
@@ -135,5 +135,6 @@ export const fileMetadataUpdate = Joi.object({
 })
 
 export const filePresignedParms = Joi.object({
-  expires: Joi.number().integer().min(1)
+  expires: Joi.number().integer().min(1),
+  token: Joi.string().uuid()
 })


### PR DESCRIPTION
Adds support for uploading/fetching files via presigned urls.

This adds two new routes full storage rules are applied to these routes.
POST `storage/presign/...` 
GET `storage/presign/...`
Each endpoint returns a json object 
```js
{
  key: fileKey,
  url: presignedUrl
}
```


URL expiry defaults to a new env variable `S3_PRESIGNED_URL_EXPIRES_DEFAULT` this has a default value of 24 hours. However, the expiry of the url can be modified in each request by passing the `expires` parameter. e.g. 
GET `storage/presign/users/${userID}avatars/headshot.jpg?expires=100` would expire in 100 seconds.

Fixes #472 