### PR TITLE
Re-add start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "report-coverage": "codecov",
     "docs:build": "vuepress build docs",
     "docs:dev": "vuepress dev docs",
-    "build": "tsc"
+    "build": "tsc",
+    "start": "node -r ./dist/start.js"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
Accidentally removed the `start` NPM script on #482 which is used on `hasura-backend-plus`'s Docker configuration.