### PR TITLE
fix: support \n in JWT_KEY

### DIFF
--- a/src/shared/config/authentication/jwt.ts
+++ b/src/shared/config/authentication/jwt.ts
@@ -6,7 +6,7 @@ import { castIntEnv, castStringArrayEnv } from '../utils'
  */
 export const JWT = {
   get KEY() {
-    return process.env.JWT_KEY || ''
+    return process.env.JWT_KEY?.replace(/\\n/g, '\n') || ''
   },
   get ALGORITHM() {
     return process.env.JWT_ALGORITHM || 'RS256'


### PR DESCRIPTION
### Issue
The env variable is keeping `\n` characters in its string.

### Solution
Replace `\n` by an actual line break.