### PR TITLE
Fix image link on docs page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,6 @@ All [Nhost](https://nhost.io) projects are built on open source software so you 
 
 <div style="text-align:center;">
   <a href="https://nhost.io/register" target="_blank" >
-    <img src="https://github.com/nhost/hasura-backend-plus/raw/master/assets/nhost-register-button.png" width="200px" />
+    <img src="https://raw.githubusercontent.com/nhost/hasura-backend-plus/master/docs/.vuepress/public/nhost-register-button.png" width="200px" />
   </a>
 </div>


### PR DESCRIPTION
I noticed the image link for your register page was broken. It looks like it got moved to `.vuepress` in another commit, but wasn't updated on the docs. You may want to move this to a more stable location instead of a link to a URL that depends on the structure of the `master` branch, but this should get it fixed for now.