### PR TITLE
Don't allow generate mfa qr code if already enabled

### DIFF
--- a/src/routes/auth/mfa/generate.ts
+++ b/src/routes/auth/mfa/generate.ts
@@ -1,10 +1,10 @@
 import { Response } from 'express'
 import { authenticator } from 'otplib'
-import { asyncWrapper, createQR } from '@shared/helpers'
+import { asyncWrapper, createQR, selectAccountByUserId } from '@shared/helpers'
 import { MFA } from '@shared/config'
 import { request } from '@shared/request'
 import { updateOtpSecret } from '@shared/queries'
-import { RequestExtended } from '@shared/types'
+import { RequestExtended, AccountData } from '@shared/types'
 
 async function generateMfa(req: RequestExtended, res: Response): Promise<unknown> {
   if (!req.permission_variables) {
@@ -12,6 +12,18 @@ async function generateMfa(req: RequestExtended, res: Response): Promise<unknown
   }
 
   const { 'user-id': user_id } = req.permission_variables
+
+  let mfa_enabled: AccountData['mfa_enabled']
+  try {
+    const account = await selectAccountByUserId(user_id)
+    mfa_enabled = account.mfa_enabled
+  } catch (err) {
+    return res.boom.badRequest(err.message)
+  }
+
+  if (mfa_enabled) {
+    return res.boom.badRequest('MFA is already enabled.')
+  }
 
   /**
    * Generate OTP secret and key URI.
@@ -24,7 +36,7 @@ async function generateMfa(req: RequestExtended, res: Response): Promise<unknown
   let image_url: string
   try {
     image_url = await createQR(otpAuth)
-  } catch(err) {
+  } catch (err) {
     return res.boom.internal(err.message)
   }
 

--- a/src/routes/auth/mfa/mfa.test.ts
+++ b/src/routes/auth/mfa/mfa.test.ts
@@ -223,9 +223,8 @@ it('should not generate mfa qr if mfa enabled for account', (done) => {
               .end((err) => {
                 if (err) return done(err)
 
-                request.post('/auth/mfa/generate').expect(400)
+                request.post('/auth/mfa/generate').expect(400).end(end(done))
               })
-              .end(end(done))
           })
       })
   })

--- a/src/routes/auth/mfa/mfa.test.ts
+++ b/src/routes/auth/mfa/mfa.test.ts
@@ -223,7 +223,11 @@ it('should not generate mfa qr if mfa enabled for account', (done) => {
               .end((err) => {
                 if (err) return done(err)
 
-                request.post('/auth/mfa/generate').expect(400).end(end(done))
+                request
+                  .post('/auth/mfa/generate')
+                  .set({ Authorization: `Bearer ${jwtToken}` })
+                  .expect(400)
+                  .end(end(done))
               })
           })
       })

--- a/src/routes/auth/mfa/mfa.test.ts
+++ b/src/routes/auth/mfa/mfa.test.ts
@@ -225,6 +225,7 @@ it('should not generate mfa qr if mfa enabled for account', (done) => {
 
                 request.post('/auth/mfa/generate').expect(400)
               })
+              .end(end(done))
           })
       })
   })


### PR DESCRIPTION
Fixes https://github.com/nhost/hasura-backend-plus/issues/590

Add a simple guard that checks that the user's MFA isn't already enabled.