### PR TITLE
Fixes ignored `STORAGE_ENABLED` env variable

### DIFF
--- a/src/shared/config/storage.ts
+++ b/src/shared/config/storage.ts
@@ -1,14 +1,30 @@
-import { castBooleanEnv } from './utils'
+import { castBooleanEnv, envExists } from './utils'
 
 /**
  * * Storage Settings
  */
 export const STORAGE = {
   get ENABLED() {
-    return castBooleanEnv('STORAGE_ENABLED') || castBooleanEnv('STORAGE_ENABLE') || true
+    if (envExists('STORAGE_ENABLED')) {
+      return castBooleanEnv('STORAGE_ENABLED')
+    }
+
+    if (envExists('STORAGE_ENABLE')) {
+      return castBooleanEnv('STORAGE_ENABLE')
+    }
+
+    return true
   },
   get S3_SSL_ENABLED() {
-    return castBooleanEnv('S3_SSL_ENABLED') || castBooleanEnv('S3_SSL_ENABLE') || true
+    if (envExists('S3_SSL_ENABLED')) {
+      return castBooleanEnv('S3_SSL_ENABLED')
+    }
+
+    if (envExists('S3_SSL_ENABLE')) {
+      return castBooleanEnv('S3_SSL_ENABLE')
+    }
+
+    return true
   },
   get S3_BUCKET() {
     return process.env.S3_BUCKET || ''

--- a/src/shared/config/utils.ts
+++ b/src/shared/config/utils.ts
@@ -7,3 +7,5 @@ export const castStringArrayEnv = (envVar: string, defaultValue: string[] = []):
   process.env[envVar]?.length
     ? (process.env[envVar] as string).split(',').map((field) => field.trim())
     : defaultValue
+export const envExists = (envVar: string): boolean =>
+  process.env[envVar] !== undefined


### PR DESCRIPTION
# Problem

Even tho I set `STORAGE_ENABLED` or `STORAGE_ENABLE` to `false`, it still trow Invalid configuration error:

```
S3_ENDPOINT undefined true
S3_BUCKET undefined true
S3_ACCESS_KEY_ID undefined true
S3_SECRET_ACCESS_KEY undefined true
/app/dist/env-vars-check.js:148
   throw new Error('Invalid configuration');
```

Problem was in this logic `castBooleanEnv('STORAGE_ENABLED') || castBooleanEnv('STORAGE_ENABLE') || true` that basically always returns `true` no matter what.

# Solution

Check if those env variables are present and only then cast boolean values from them.

---

Fixes https://github.com/nhost/hasura-backend-plus/issues/621