### PR TITLE
Fix protocol on docker-compose dev

### DIFF
--- a/docker/dev/docker-compose-example.yaml
+++ b/docker/dev/docker-compose-example.yaml
@@ -51,7 +51,7 @@ services:
       JWT_KEY: >-
         jhyu89jiuhyg7678hoijhuytf7ghjiasodibagsdga9dha8os7df97a6sdgh9asudgo7f7g8h1uuoyafsod8pgasipdg8aps9dhai;sd
       JWT_ALGORITHM: HS256
-      ALLOWED_REDIRECT_URLS: 'htt://localhost'
+      ALLOWED_REDIRECT_URLS: 'http://localhost'
       JWT_CUSTOM_FIELDS: ''
       S3_ENDPOINT: 'minio:9000'
       S3_SSL_ENABLED: 'false'


### PR DESCRIPTION
Fix the protocol value on the `ALLOWED_REDIRECT_URLS` env value. It was `htt` and should be `http`.